### PR TITLE
Extract API helpers and add JSON response metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api
 ```
 
 Filter with `?filter=static`, `?filter=parameterized`, `?filter=pages`, or `?filter=resolver`.
+Responses keep the existing top-level `urls` and `count` fields and also include a `metadata` object with:
+
+- `generated_at`
+- `applied_filter`
+- `total_count`
+- `testable_count`
+- `untestable_count`
+- `package_version`
 
 For full API response examples and detailed feature documentation, see [docs/usage.md](docs/usage.md).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -65,7 +65,15 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
       "view_name": "wagtail.admin.views.home.HomeView"
     }
   ],
-  "count": 190
+  "count": 190,
+  "metadata": {
+    "generated_at": "2026-03-02T12:34:56+00:00",
+    "applied_filter": null,
+    "total_count": 190,
+    "testable_count": 150,
+    "untestable_count": 40,
+    "package_version": "0.1.0"
+  }
 }
 ```
 
@@ -87,6 +95,17 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
 The API requires a Bearer token matching `WAGTAIL_UNVEIL_API_KEY` (from environment or Django settings).
 If both are set, environment is used. Requests without a valid key receive a `403` response.
 If no key is configured in either place, the endpoint returns `500`.
+
+### Metadata
+
+Both JSON endpoints include a `metadata` object alongside the existing top-level `urls` and `count` fields.
+
+- `generated_at` — ISO 8601 timestamp for when the response was generated
+- `applied_filter` — the recognised `filter` value that was applied, or `null`
+- `total_count` — total URLs returned in the response
+- `testable_count` — number of URLs marked testable
+- `untestable_count` — number of URLs marked untestable
+- `package_version` — installed `wagtail-unveil` package version
 
 ## HTML Reports
 

--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -1,4 +1,5 @@
 import json
+from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
@@ -7,7 +8,7 @@ from wagtail.test.utils import WagtailTestUtils
 
 from tests.utils import BaseAPIViewTestMixin, BaseReportViewTestMixin
 from wagtail_unveil.discovery.backend import BackendURL
-from wagtail_unveil.views import _authenticate_api_request, _serialize_backend_url
+from wagtail_unveil.views import _authenticate_api_request, _get_package_version, _serialize_backend_url
 from wagtail_unveil.wagtail_hooks import UnveilReportPanel
 
 
@@ -21,6 +22,8 @@ class TestAdminUrlsAPIView(BaseAPIViewTestMixin, TestCase):
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         data = response.json()
+        self.assertEqual(data["metadata"]["applied_filter"], "static")
+        self.assertEqual(data["metadata"]["total_count"], data["count"])
         for url in data["urls"]:
             self.assertFalse(url["has_parameters"], url["route"])
 
@@ -30,8 +33,17 @@ class TestAdminUrlsAPIView(BaseAPIViewTestMixin, TestCase):
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         data = response.json()
+        self.assertEqual(data["metadata"]["applied_filter"], "parameterized")
+        self.assertEqual(data["metadata"]["total_count"], data["count"])
         for url in data["urls"]:
             self.assertTrue(url["has_parameters"], url["route"])
+
+    def test_invalid_filter_does_not_apply_metadata_filter(self):
+        response = self.client.get(
+            "/unveil/api/admin-urls/?filter=unknown",
+            HTTP_AUTHORIZATION="Bearer test-secret",
+        )
+        self.assertIsNone(response.json()["metadata"]["applied_filter"])
 
 
 class TestAdminAPIViewHelpers(TestCase):
@@ -84,6 +96,10 @@ class TestAdminAPIViewHelpers(TestCase):
                 "resolved_route": "admin/pages/1/edit/",
             },
         )
+
+    def test_get_package_version_returns_empty_string_when_lookup_fails(self):
+        with patch("wagtail_unveil.views.version", side_effect=PackageNotFoundError):
+            self.assertEqual(_get_package_version(), "")
 
 
 @override_settings(DEBUG=True)

--- a/tests/test_frontend_views.py
+++ b/tests/test_frontend_views.py
@@ -20,6 +20,8 @@ class TestFrontendUrlsAPIView(BaseAPIViewTestMixin, TestCase):
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         data = response.json()
+        self.assertEqual(data["metadata"]["applied_filter"], "pages")
+        self.assertEqual(data["metadata"]["total_count"], data["count"])
         for url in data["urls"]:
             self.assertEqual(url["source"], "page")
 
@@ -29,8 +31,17 @@ class TestFrontendUrlsAPIView(BaseAPIViewTestMixin, TestCase):
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         data = response.json()
+        self.assertEqual(data["metadata"]["applied_filter"], "resolver")
+        self.assertEqual(data["metadata"]["total_count"], data["count"])
         for url in data["urls"]:
             self.assertEqual(url["source"], "resolver")
+
+    def test_invalid_filter_does_not_apply_metadata_filter(self):
+        response = self.client.get(
+            "/unveil/api/frontend-urls/?filter=unknown",
+            HTTP_AUTHORIZATION="Bearer test-secret",
+        )
+        self.assertIsNone(response.json()["metadata"]["applied_filter"])
 
 
 class TestFrontendAPIViewHelpers(TestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
@@ -17,8 +18,30 @@ class BaseAPIViewTestMixin:
         data = response.json()
         self.assertIn("urls", data)
         self.assertIn("count", data)
+        self.assertIn("metadata", data)
         self.assertGreater(data["count"], 0)
         self.assertEqual(len(data["urls"]), data["count"])
+        self.assertEqual(data["metadata"]["total_count"], data["count"])
+
+    @patch("wagtail_unveil.views._get_package_version", return_value="9.9.9")
+    @patch("wagtail_unveil.views.timezone.now")
+    def test_returns_metadata(self, mock_now, _mock_version):
+        mock_now.return_value = datetime(2026, 3, 2, 12, 34, 56, tzinfo=timezone.utc)
+
+        response = self.client.get(
+            self.api_url,
+            HTTP_AUTHORIZATION="Bearer test-secret",
+        )
+
+        metadata = response.json()["metadata"]
+        self.assertEqual(metadata["generated_at"], "2026-03-02T12:34:56+00:00")
+        self.assertIsNone(metadata["applied_filter"])
+        self.assertEqual(metadata["package_version"], "9.9.9")
+        self.assertEqual(metadata["total_count"], response.json()["count"])
+        self.assertEqual(
+            metadata["testable_count"] + metadata["untestable_count"],
+            metadata["total_count"],
+        )
 
     def test_requires_api_key(self):
         response = self.client.get(self.api_url)

--- a/wagtail_unveil/AGENTS.md
+++ b/wagtail_unveil/AGENTS.md
@@ -52,6 +52,17 @@ The package exports one URL namespace:
 
 Do not document or reintroduce the old split `api_urls.py` / `report_urls.py` namespace layout unless the code changes back to that design.
 
+### JSON Response Shape
+
+JSON API endpoints preserve top-level `urls` and `count` fields and also return a `metadata` object containing:
+
+- `generated_at`
+- `applied_filter`
+- `total_count`
+- `testable_count`
+- `untestable_count`
+- `package_version`
+
 ## Discovery Notes
 
 ### Admin URLs

--- a/wagtail_unveil/views.py
+++ b/wagtail_unveil/views.py
@@ -1,6 +1,9 @@
+from importlib.metadata import PackageNotFoundError, version
+
 from django.conf import settings
 from django.http import HttpResponseNotFound, JsonResponse
 from django.shortcuts import render
+from django.utils import timezone
 from wagtail.admin.auth import user_passes_test
 
 from wagtail_unveil.discovery.backend import get_admin_urls
@@ -53,11 +56,33 @@ def _serialize_frontend_url(url):
     }
 
 
-def _build_urls_json_response(urls, serializer):
+def _get_package_version():
+    """Return the installed wagtail-unveil package version, or an empty string."""
+    try:
+        return version("wagtail-unveil")
+    except PackageNotFoundError:
+        return ""
+
+
+def _build_urls_metadata(urls, *, applied_filter):
+    """Build metadata describing how a URL payload was produced."""
+    testable_count = sum(1 for url in urls if url.is_testable)
+    return {
+        "generated_at": timezone.now().isoformat(),
+        "applied_filter": applied_filter,
+        "total_count": len(urls),
+        "testable_count": testable_count,
+        "untestable_count": len(urls) - testable_count,
+        "package_version": _get_package_version(),
+    }
+
+
+def _build_urls_json_response(urls, serializer, *, applied_filter=None):
     """Serialize URL entries and wrap them in the standard JSON payload."""
     data = {
         "urls": [serializer(url) for url in urls],
         "count": len(urls),
+        "metadata": _build_urls_metadata(urls, applied_filter=applied_filter),
     }
     return JsonResponse(data)
 
@@ -71,12 +96,15 @@ def admin_urls_json(request):
     urls = get_admin_urls()
 
     url_filter = request.GET.get("filter")
+    applied_filter = None
     if url_filter == "static":
         urls = [u for u in urls if not u.has_parameters]
+        applied_filter = url_filter
     elif url_filter == "parameterized":
         urls = [u for u in urls if u.has_parameters]
+        applied_filter = url_filter
 
-    return _build_urls_json_response(urls, _serialize_backend_url)
+    return _build_urls_json_response(urls, _serialize_backend_url, applied_filter=applied_filter)
 
 
 @user_passes_test(lambda u: u.is_superuser)
@@ -105,12 +133,15 @@ def frontend_urls_json(request):
     urls = get_frontend_urls()
 
     source_filter = request.GET.get("filter")
+    applied_filter = None
     if source_filter == "pages":
         urls = [u for u in urls if u.source == "page"]
+        applied_filter = source_filter
     elif source_filter == "resolver":
         urls = [u for u in urls if u.source == "resolver"]
+        applied_filter = source_filter
 
-    return _build_urls_json_response(urls, _serialize_frontend_url)
+    return _build_urls_json_response(urls, _serialize_frontend_url, applied_filter=applied_filter)
 
 
 @user_passes_test(lambda u: u.is_superuser)


### PR DESCRIPTION
## Summary
- extract shared JSON API authentication, error handling, and URL serialization helpers
- add a backward-compatible metadata object to both JSON API responses
- document the API metadata contract and extend endpoint/helper coverage

## Testing
- make lint
- make coverage

Closes #9
Closes #13