### PR TITLE
Rename admin URL endpoints to backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,9 +71,9 @@ path("unveil/", include("wagtail_unveil.urls"))
 
 Routes provided:
 
-- `api/admin-urls/` → `wagtail_unveil:api_admin_urls`
+- `api/backend-urls/` → `wagtail_unveil:api_backend_urls`
 - `api/frontend-urls/` → `wagtail_unveil:api_frontend_urls`
-- `report/admin-urls/` → `wagtail_unveil:report_admin_urls`
+- `report/backend-urls/` → `wagtail_unveil:report_backend_urls`
 - `report/frontend-urls/` → `wagtail_unveil:report_frontend_urls`
 
 JSON endpoints use Bearer token auth via `WAGTAIL_UNVEIL_API_KEY`. HTML report views require a superuser and `DEBUG=True`.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ urlpatterns = [
 ]
 ```
 
-Then visit `/unveil/report/admin-urls/` or `/unveil/report/frontend-urls/` while logged in as a superuser (requires `DEBUG=True`).
+Then visit `/unveil/report/backend-urls/` or `/unveil/report/frontend-urls/` while logged in as a superuser (requires `DEBUG=True`).
 
 ## Usage
 
@@ -62,7 +62,7 @@ Then visit `/unveil/report/admin-urls/` or `/unveil/report/frontend-urls/` while
 
 Interactive browser-based reports with one-click URL testing. Requires superuser login and `DEBUG=True`.
 
-- **Admin URLs Report** — `/unveil/report/admin-urls/`
+- **Admin URLs Report** — `/unveil/report/backend-urls/`
 - **Frontend URLs Report** — `/unveil/report/frontend-urls/`
 
 ### JSON API
@@ -73,7 +73,7 @@ Set `WAGTAIL_UNVEIL_API_KEY` via environment variable (recommended) or Django se
 If both are set, the environment variable takes precedence.
 
 ```bash
-curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/admin-urls/
+curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/backend-urls/
 curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/frontend-urls/
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -43,13 +43,13 @@ so `"/__debug__/"` and `"__debug__/"` are equivalent. Invalid values are silentl
 
 ```bash
 # All admin URLs
-curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/admin-urls/
+curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/backend-urls/
 
 # Static URLs only
-curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/api/admin-urls/?filter=static"
+curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/api/backend-urls/?filter=static"
 
 # Parameterized URLs only
-curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/api/admin-urls/?filter=parameterized"
+curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/api/backend-urls/?filter=parameterized"
 ```
 
 **Response:**
@@ -117,7 +117,7 @@ Reports require **superuser login** and **`DEBUG=True`**.
 
 ### Admin URLs Report
 
-Visit `/unveil/report/admin-urls/` while logged into the Wagtail admin.
+Visit `/unveil/report/backend-urls/` while logged into the Wagtail admin.
 
 **Features:**
 

--- a/sandbox/home/templates/home/home_page.html
+++ b/sandbox/home/templates/home/home_page.html
@@ -32,7 +32,7 @@
 <h2>Admin Links</h2>
 <ul>
     <li><a href="{% url 'wagtailadmin_home' %}">Wagtail Admin</a></li>
-    <li><a href="{% url 'wagtail_unveil:report_admin_urls' %}">Unveil Admin URLs Report</a></li>
+    <li><a href="{% url 'wagtail_unveil:report_backend_urls' %}">Unveil Admin URLs Report</a></li>
     <li><a href="{% url 'wagtail_unveil:report_frontend_urls' %}">Unveil Frontend URLs Report</a></li>
 </ul>
 {% endblock content %}

--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -14,11 +14,11 @@ from wagtail_unveil.wagtail_hooks import UnveilReportPanel
 
 @patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"})
 class TestAdminUrlsAPIView(BaseAPIViewTestMixin, TestCase):
-    api_url = "/unveil/api/admin-urls/"
+    api_url = "/unveil/api/backend-urls/"
 
     def test_filter_static(self):
         response = self.client.get(
-            "/unveil/api/admin-urls/?filter=static",
+            "/unveil/api/backend-urls/?filter=static",
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         data = response.json()
@@ -29,7 +29,7 @@ class TestAdminUrlsAPIView(BaseAPIViewTestMixin, TestCase):
 
     def test_filter_parameterized(self):
         response = self.client.get(
-            "/unveil/api/admin-urls/?filter=parameterized",
+            "/unveil/api/backend-urls/?filter=parameterized",
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         data = response.json()
@@ -40,7 +40,7 @@ class TestAdminUrlsAPIView(BaseAPIViewTestMixin, TestCase):
 
     def test_invalid_filter_does_not_apply_metadata_filter(self):
         response = self.client.get(
-            "/unveil/api/admin-urls/?filter=unknown",
+            "/unveil/api/backend-urls/?filter=unknown",
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         self.assertIsNone(response.json()["metadata"]["applied_filter"])
@@ -53,7 +53,7 @@ class TestAdminAPIViewHelpers(TestCase):
     @patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"})
     def test_authenticate_api_request_accepts_matching_bearer_token(self):
         request = self.factory.get(
-            "/unveil/api/admin-urls/",
+            "/unveil/api/backend-urls/",
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         self.assertIsNone(_authenticate_api_request(request))
@@ -61,7 +61,7 @@ class TestAdminAPIViewHelpers(TestCase):
     @patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"})
     def test_authenticate_api_request_rejects_wrong_bearer_token(self):
         request = self.factory.get(
-            "/unveil/api/admin-urls/",
+            "/unveil/api/backend-urls/",
             HTTP_AUTHORIZATION="Bearer wrong-key",
         )
         response = _authenticate_api_request(request)
@@ -104,31 +104,31 @@ class TestAdminAPIViewHelpers(TestCase):
 
 @override_settings(DEBUG=True)
 class TestAdminUrlsReportView(BaseReportViewTestMixin, WagtailTestUtils, TestCase):
-    report_url = "/unveil/report/admin-urls/"
+    report_url = "/unveil/report/backend-urls/"
     report_title = "Admin URLs Report"
 
     def setUp(self):
         self.login()
 
     def test_report_contains_known_url(self):
-        response = self.client.get("/unveil/report/admin-urls/")
+        response = self.client.get("/unveil/report/backend-urls/")
         self.assertContains(response, "wagtailadmin_home")
 
     def test_report_disables_test_for_non_testable(self):
-        response = self.client.get("/unveil/report/admin-urls/")
+        response = self.client.get("/unveil/report/backend-urls/")
         self.assertContains(response, "disabled")
         self.assertContains(response, "POST-only view")
         self.assertContains(response, "Intentional error endpoint")
 
     def test_report_shows_all_rows_by_default(self):
-        response = self.client.get("/unveil/report/admin-urls/")
+        response = self.client.get("/unveil/report/backend-urls/")
         content = response.content.decode()
         self.assertIn('data-has-parameters="true"', content)
         self.assertIn('data-has-parameters="false"', content)
         self.assertNotIn('class="hidden"', content.split("<tbody>")[1].split("</tbody>")[0])
 
     def test_report_has_help_button(self):
-        response = self.client.get("/unveil/report/admin-urls/")
+        response = self.client.get("/unveil/report/backend-urls/")
         self.assertContains(response, "unveil-help-button")
 
 
@@ -148,7 +148,7 @@ class TestDashboardPanel(TestCase):
     def test_panel_visible_for_superuser(self):
         html = self._render(self.superuser)
         self.assertIn("View Admin URLs Report", html)
-        self.assertIn("/unveil/report/admin-urls/", html)
+        self.assertIn("/unveil/report/backend-urls/", html)
         self.assertIn("w-panel w-panel--dashboard", html)
 
     def test_panel_hidden_for_non_superuser(self):

--- a/wagtail_unveil/AGENTS.md
+++ b/wagtail_unveil/AGENTS.md
@@ -46,9 +46,9 @@ Do not document or assume package management commands unless they are reintroduc
 
 The package exports one URL namespace:
 
-- `wagtail_unveil:api_admin_urls`
+- `wagtail_unveil:api_backend_urls`
 - `wagtail_unveil:api_frontend_urls`
-- `wagtail_unveil:report_admin_urls`
+- `wagtail_unveil:report_backend_urls`
 - `wagtail_unveil:report_frontend_urls`
 
 Do not document or reintroduce the old split `api_urls.py` / `report_urls.py` namespace layout unless the code changes back to that design.

--- a/wagtail_unveil/templates/wagtail_unveil/base_report.html
+++ b/wagtail_unveil/templates/wagtail_unveil/base_report.html
@@ -10,7 +10,7 @@
 <body>
     <nav class="report-nav">
         <a href="/">Home</a>
-        <a class="{% block admin_nav_class %}{% endblock %}" href="{% url 'wagtail_unveil:report_admin_urls' %}">Admin URLs</a>
+        <a class="{% block admin_nav_class %}{% endblock %}" href="{% url 'wagtail_unveil:report_backend_urls' %}">Admin URLs</a>
         <a class="{% block frontend_nav_class %}{% endblock %}" href="{% url 'wagtail_unveil:report_frontend_urls' %}">Frontend URLs</a>
         <a href="{% url 'wagtailadmin_home' %}">Wagtail Admin</a>
     </nav>

--- a/wagtail_unveil/templates/wagtail_unveil/dashboard_panel.html
+++ b/wagtail_unveil/templates/wagtail_unveil/dashboard_panel.html
@@ -5,7 +5,7 @@
     </div>
     <div class="w-panel__content" style="padding: 0.5em 1em;">
         <p>View the reports:</p>
-        <a href="{% url 'wagtail_unveil:report_admin_urls' %}" rel="noopener noreferrer" class="button button-small button-secondary">View Admin URLs Report</a>
+        <a href="{% url 'wagtail_unveil:report_backend_urls' %}" rel="noopener noreferrer" class="button button-small button-secondary">View Admin URLs Report</a>
         <a href="{% url 'wagtail_unveil:report_frontend_urls' %}" rel="noopener noreferrer" class="button button-small button-secondary">View Frontend URLs Report</a>
     </div>
 </section>

--- a/wagtail_unveil/urls.py
+++ b/wagtail_unveil/urls.py
@@ -5,8 +5,8 @@ from wagtail_unveil.views import admin_urls_json, admin_urls_report, frontend_ur
 app_name = "wagtail_unveil"
 
 urlpatterns = [
-    path("api/admin-urls/", admin_urls_json, name="api_admin_urls"),
+    path("api/backend-urls/", admin_urls_json, name="api_backend_urls"),
     path("api/frontend-urls/", frontend_urls_json, name="api_frontend_urls"),
-    path("report/admin-urls/", admin_urls_report, name="report_admin_urls"),
+    path("report/backend-urls/", admin_urls_report, name="report_backend_urls"),
     path("report/frontend-urls/", frontend_urls_report, name="report_frontend_urls"),
 ]


### PR DESCRIPTION
## Summary
- rename the public admin API/report routes to backend routes
- update reverse lookups, tests, and docs to use the new names
- keep frontend route names unchanged

Closes #20