### PR TITLE
Add sandbox frontend error route

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ make pre-commit # Run pre-commit hooks on all files
 
 The report UI intentionally uses plain static JavaScript files in `wagtail_unveil/static/wagtail_unveil/js/`, loaded in template order without a build step. Keep client-side concerns split into focused files rather than reintroducing a single report script.
 
+The sandbox also includes a deliberate failing frontend route at `/intentional-error/` so local report runs always have at least one visible error case.
+
 See [AGENTS.md](AGENTS.md) for the full list of development commands and agent-facing project guidance.
 
 ## License

--- a/sandbox/home/views.py
+++ b/sandbox/home/views.py
@@ -1,0 +1,6 @@
+from django.http import HttpResponseServerError
+
+
+def intentional_frontend_error(_request):
+    """Sandbox-only endpoint that reliably returns a 500 for report testing."""
+    return HttpResponseServerError("Intentional frontend error")

--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -6,6 +6,7 @@ from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.images import urls as wagtailimages_urls
 
+from sandbox.home import views as home_views
 from sandbox.search import views as search_views
 
 urlpatterns = [
@@ -14,6 +15,11 @@ urlpatterns = [
     path("documents/", include(wagtaildocs_urls)),
     path("images/", include(wagtailimages_urls)),
     path("search/", search_views.search, name="search"),
+    path(
+        "intentional-error/",
+        home_views.intentional_frontend_error,
+        name="intentional_frontend_error",
+    ),
     path("unveil/", include("wagtail_unveil.urls")),
 ]
 

--- a/tests/test_sandbox_urls.py
+++ b/tests/test_sandbox_urls.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+
+from wagtail_unveil.discovery.frontend import get_frontend_urls
+
+
+class TestSandboxIntentionalFrontendError(TestCase):
+    def test_intentional_error_route_is_discovered_as_testable_resolver_url(self):
+        urls = [url for url in get_frontend_urls() if url.name == "intentional_frontend_error"]
+
+        self.assertEqual(len(urls), 1)
+        self.assertEqual(urls[0].url, "/intentional-error/")
+        self.assertEqual(urls[0].source, "resolver")
+        self.assertTrue(urls[0].is_testable)
+        self.assertEqual(urls[0].skip_reason, "")
+
+    def test_intentional_error_route_returns_500(self):
+        response = self.client.get("/intentional-error/")
+
+        self.assertEqual(response.status_code, 500)
+        self.assertContains(response, "Intentional frontend error", status_code=500)


### PR DESCRIPTION
## Summary
- add a sandbox-only frontend route that intentionally returns a 500 response
- cover discovery and request behavior with tests so the frontend report always has one visible error case in the sandbox
- document the deliberate failing route in the development README

Closes #21

## Testing
- uv run --env-file .env django-admin test tests.test_sandbox_urls tests.test_frontend_urls tests.test_frontend_views
- make lint
- make coverage