### PR TITLE
Separate discovery phases from testability classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ make pre-commit # Run pre-commit hooks on all files
 
 The report UI intentionally uses plain static JavaScript files in `wagtail_unveil/static/wagtail_unveil/js/`, loaded in template order without a build step. Keep client-side concerns split into focused files rather than reintroducing a single report script.
 
-Admin URL parameter resolution follows an explicit ordered strategy pipeline; see [docs/discovery-architecture.md](docs/discovery-architecture.md) when changing fallback behavior or special cases.
+Discovery now follows explicit internal phases for backend and frontend routes, and admin parameter resolution uses an ordered strategy pipeline; see [docs/discovery-architecture.md](docs/discovery-architecture.md) when changing fallback behavior or classification rules.
 
 The sandbox also includes a deliberate failing frontend route at `/intentional-error/` so local report runs always have at least one visible error case.
 

--- a/docs/discovery-architecture.md
+++ b/docs/discovery-architecture.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document explains how `wagtail_unveil` discovers URLs, normalizes route strings, resolves parameterized admin routes, and classifies URLs as testable or untestable. It is intended for contributors and coding agents working on discovery behavior.
+This document explains how `wagtail_unveil` discovers URLs, normalizes route strings, classifies URLs as testable or untestable, resolves supported parameterized admin routes, and emits the final public dataclasses. It is intended for contributors and coding agents working on discovery behavior.
 
 Primary implementation files:
 
@@ -13,27 +13,32 @@ Primary implementation files:
 
 ## Shared Discovery Building Blocks
 
-Two helpers underpin both admin and frontend discovery:
+The discovery modules now follow the same internal phase model:
+
+1. discover raw candidates
+2. normalize route metadata
+3. classify testability and skip reasons
+4. resolve supported parameterized admin routes
+5. emit the final public dataclass instances
+
+Shared low-level helpers underpin both admin and frontend discovery:
 
 - `walk_patterns(patterns, prefix="", namespace="")` recursively walks Django `URLResolver` and `URLPattern` objects and yields `(route, name, namespace, callback)` tuples.
 - `clean_regex_route(route)` removes `^` and `$` anchors and converts named regex groups such as `(?P<pk>...)` into path-style placeholders such as `<pk>`.
+- `route_has_parameters(route)` identifies normalized routes that still contain `<...>` placeholders.
+- `route_contains_regex(route)` identifies normalized routes that still contain regex grouping syntax and should remain visible but untestable in frontend discovery.
 
 Normalization is intentionally partial. Some routes still contain regex constructs after cleanup, which means they may be discovered but remain untestable, or in the admin case may be skipped entirely if they still look unsafe for direct testing.
 
 ## Admin Discovery Flow
 
-`get_admin_urls()` in `wagtail_unveil/discovery/backend.py` follows this sequence:
+`get_admin_urls()` in `wagtail_unveil/discovery/backend.py` is now a small orchestrator over explicit phases:
 
-1. Walk the root URL resolver with `walk_patterns()`.
-2. Keep only routes whose raw route string starts with `admin/`.
-3. Normalize the route with `clean_regex_route()`.
-4. Drop routes that still contain problematic regex metacharacters after cleanup, such as catch-all patterns.
-5. Apply `WAGTAIL_UNVEIL_SKIP_URL_PREFIXES`.
-6. Mark whether the route still has path parameters by checking for `<...>` placeholders.
-7. Apply hard-coded non-testable name rules.
-8. Check whether related serve URLs are registered for document and image URLs that depend on them.
-9. Attempt to resolve parameterized URLs to a concrete path.
-10. Emit a `BackendURL` dataclass with discovery and testability metadata.
+1. `_discover_admin_routes()` walks the root URL resolver with `walk_patterns()` and keeps only raw routes whose route string starts with `admin/`.
+2. `_normalize_admin_route()` cleans the route with `clean_regex_route()`, drops routes that still contain unsafe regex metacharacters after cleanup, applies `WAGTAIL_UNVEIL_SKIP_URL_PREFIXES`, and computes normalized metadata such as `has_parameters` and `view_name`.
+3. `_classify_admin_route()` assigns testability for hard-coded non-testable names and serve-readiness checks, and marks parameterized routes as needing resolution without immediately assigning `URL requires parameters`.
+4. `_finalize_admin_route()` attempts backend parameter resolution for routes that need it.
+5. `_finalize_admin_route()` emits the final `BackendURL`, assigning `URL requires parameters` only if resolution fails.
 
 Current hard-coded non-testable names:
 
@@ -52,7 +57,7 @@ There are also namespace-specific readiness checks:
 
 ## Parameter Resolution Strategy
 
-`_resolve_parameterized_url()` attempts to turn a parameterized admin route into a real path that can be tested. It now follows an explicit strategy pipeline:
+Backend parameter resolution is phase 4 only. `_resolve_parameterized_url()` attempts to turn a parameterized admin route into a real path that can be tested. It follows an explicit strategy pipeline:
 
 1. If the namespace is `wagtailsettings`, delegate to `_resolve_settings_url()` and stop there.
 2. Try to infer a model from callback metadata via `_get_model_from_callback()`.
@@ -68,7 +73,7 @@ There are also namespace-specific readiness checks:
 
 Internal resolution returns a `_ParameterizedURLResolution` object with `resolved_route`, `resolved`, `method`, `detail`, and `attempts`. This metadata is internal only. It exists to make the fallback order and failure path easier to debug and test. Public JSON responses still expose only the existing `BackendURL` fields.
 
-Resolved URLs are stored in `resolved_route` on `BackendURL`. If reversal fails or no suitable instance exists, the parameterized URL remains in the results but is marked untestable with `URL requires parameters`. Namespace-specific overrides can invalidate an earlier candidate instance when the route requires a different model type.
+Resolved URLs are stored in `resolved_route` on `BackendURL`. If reversal fails or no suitable instance exists, the parameterized URL remains in the results but is marked untestable with `URL requires parameters` during final emission rather than during initial classification. Namespace-specific overrides can invalidate an earlier candidate instance when the route requires a different model type.
 
 ### Settings Resolution Nuances
 
@@ -86,46 +91,46 @@ This logic exists to support the currently targeted Wagtail versions, including 
 
 ## Frontend Discovery Flow
 
-`get_frontend_urls()` combines two sources:
+`get_frontend_urls()` now orchestrates the same phased flow for two sources:
 
-- page-derived URLs from `_get_page_urls()`
-- resolver-derived non-admin URLs from `_get_resolver_frontend_urls()`
+- page-derived candidates from `_discover_page_candidates()`
+- resolver-derived candidates from `_discover_resolver_candidates()`
 
-The combined return value is a flat list of `FrontendURL` dataclass instances.
+Each candidate is classified by `_classify_frontend_candidate()` and emitted as a `FrontendURL` by `_build_frontend_url()`.
 
 ## Frontend Page Discovery
 
-`_get_page_urls()` builds page-derived frontend entries in this order:
+`_discover_page_candidates()` builds page-derived frontend candidates in this order:
 
 1. Iterate `Page.objects.live().specific()`.
 2. Skip the base `Page` type.
 3. Read `page.url` defensively so pages that error during URL generation do not break discovery.
 4. Convert absolute page URLs to path-only values via `urlparse()`.
 5. Apply `WAGTAIL_UNVEIL_SKIP_URL_PREFIXES`.
-6. Emit one base page entry for the page URL.
-7. If the page is a `FormMixin` subclass, add a second entry for the landing page and mark it untestable with `Requires POST submission`.
-8. If the page is a `RoutablePageMixin` subclass, add sub-route entries from `_get_routable_sub_urls()`.
-9. After collecting all page entries, apply `WAGTAIL_UNVEIL_PAGES_PER_TYPE` by grouping on `(page_type, page_title)` so each selected page keeps all of its related entries.
+6. Emit one base page candidate for the page URL.
+7. If the page is a `FormMixin` subclass, add a second landing-page candidate and leave classification to a later phase.
+8. If the page is a `RoutablePageMixin` subclass, add sub-route candidates from `_discover_routable_page_candidates()`.
+9. After collecting all page candidates, `_apply_page_limit()` applies `WAGTAIL_UNVEIL_PAGES_PER_TYPE` by grouping on `(page_type, page_title)` so each selected page keeps all of its related entries.
 
 `WAGTAIL_UNVEIL_PAGES_PER_TYPE` affects page-derived URLs only. Resolver-derived frontend URLs are not limited by that setting.
 
 ## Routable Page Special Cases
 
-`_get_routable_sub_urls()` discovers routes defined with `RoutablePageMixin.get_subpage_urls()` and handles them as follows:
+`_discover_routable_page_candidates()` discovers routes defined with `RoutablePageMixin.get_subpage_urls()` and handles them as follows:
 
 - use `pattern.pattern._route` when available
 - otherwise fall back to `pattern.pattern._regex` plus `clean_regex_route()`
 - skip the empty index route so the base page URL is not duplicated
 - construct a full URL by joining the page path and sub-route
 - apply skip prefixes to the full URL
-- mark routes containing `<...>` placeholders as untestable with `URL requires parameters`
-- keep static sub-routes testable
+- record whether the sub-route contains `<...>` placeholders
+- leave the final testability decision to classification
 
 This means routable pages contribute both their base page URL and any additional sub-routes, but parameterized sub-routes are represented rather than auto-resolved.
 
 ## Frontend Resolver Discovery
 
-`_get_resolver_frontend_urls()` walks the root resolver and emits non-admin routes with these exclusions and rules:
+`_discover_resolver_candidates()` walks the root resolver and emits non-admin candidates with these exclusions and rules:
 
 1. Walk all URL patterns with `walk_patterns()`.
 2. Exclude routes under `admin/`.
@@ -133,15 +138,21 @@ This means routable pages contribute both their base page URL and any additional
 4. Exclude routes whose namespace is `wagtail_unveil`.
 5. Apply `WAGTAIL_UNVEIL_SKIP_URL_PREFIXES`.
 6. Normalize the route with `clean_regex_route()`.
-7. Mark routes containing `<...>` placeholders as untestable with `URL requires parameters`.
-8. Otherwise, if the normalized route still contains `(`, mark it untestable with `URL contains regex patterns`.
-9. Emit a `FrontendURL`.
+7. Record whether the normalized route contains `<...>` placeholders.
+8. Record whether the normalized route still contains regex groups such as `(`.
+9. Emit the final `FrontendURL` only after classification and build steps.
 
 Resolver-derived URLs are still included when untestable so they remain visible in reports and API responses.
 
 ## Testability Classification
 
 Discovery and testability are separate concepts in this package. A URL can be discovered successfully and still be intentionally marked untestable. Untestable URLs remain in the output with a `skip_reason` so contributors can see why they are excluded from direct GET testing.
+
+Classification is the only step that should decide why a route is not directly GET-testable:
+
+- backend classification owns hard-coded non-testable names and serve-readiness checks
+- frontend classification owns `Requires POST submission`, `URL requires parameters`, and `URL contains regex patterns`
+- backend finalization adds `URL requires parameters` only when a route required resolution and no concrete path could be produced
 
 Current skip reasons used by the discovery layer:
 

--- a/tests/test_admin_urls.py
+++ b/tests/test_admin_urls.py
@@ -9,14 +9,19 @@ from wagtail.models import Site
 
 from wagtail_unveil.discovery.backend import (
     BackendURL,
+    _AdminClassification,
+    _classify_admin_route,
+    _DiscoveredAdminRoute,
+    _finalize_admin_route,
     _get_instance_for_model,
     _get_model_from_modeladmin_name,
     _get_namespace_specific_instance,
+    _normalize_admin_route,
     _resolve_parameterized_url,
     _resolve_settings_url,
     get_admin_urls,
 )
-from wagtail_unveil.discovery.utils import clean_regex_route
+from wagtail_unveil.discovery.utils import clean_regex_route, route_contains_regex, route_has_parameters
 
 
 class TestGetAdminUrls(TestCase):
@@ -109,6 +114,131 @@ class TestCleanRegexRoute(TestCase):
             clean_regex_route("^a/(?P<pk>[0-9]+)/b/(?P<slug>[-\\w]+)/$"),
             "a/<pk>/b/<slug>/",
         )
+
+    def test_route_has_parameters(self):
+        self.assertTrue(route_has_parameters("admin/images/<int:image_id>/"))
+        self.assertFalse(route_has_parameters("admin/images/"))
+
+    def test_route_contains_regex(self):
+        self.assertTrue(route_contains_regex("documents/(.*)/"))
+        self.assertFalse(route_contains_regex("documents/<path:path>/"))
+
+
+class TestAdminDiscoveryPhases(TestCase):
+    def test_normalization_cleans_route_and_sets_metadata(self):
+        def callback(request):
+            return None
+
+        discovered = _DiscoveredAdminRoute(
+            raw_route="^admin/example/(?P<pk>[0-9]+)/$",
+            name="example_edit",
+            namespace="example",
+            callback=callback,
+        )
+
+        normalized = _normalize_admin_route(discovered, skip_prefixes=[])
+
+        self.assertIsNotNone(normalized)
+        self.assertEqual(normalized.route, "admin/example/<pk>/")
+        self.assertTrue(normalized.has_parameters)
+        self.assertTrue(normalized.view_name.endswith(".callback"))
+
+    def test_normalization_drops_routes_with_unsafe_regex(self):
+        discovered = _DiscoveredAdminRoute(
+            raw_route="admin/catch-all/.*/",
+            name="unsafe",
+            namespace="",
+            callback=lambda request: None,
+        )
+
+        normalized = _normalize_admin_route(discovered, skip_prefixes=[])
+
+        self.assertIsNone(normalized)
+
+    def test_classification_marks_known_non_testable_name(self):
+        normalized = _normalize_admin_route(
+            _DiscoveredAdminRoute(
+                raw_route="admin/logout/",
+                name="wagtailadmin_logout",
+                namespace="wagtailadmin",
+                callback=lambda request: None,
+            ),
+            skip_prefixes=[],
+        )
+
+        classification = _classify_admin_route(
+            normalized,
+            docs_serve_available=True,
+            images_serve_available=True,
+        )
+
+        self.assertFalse(classification.is_testable)
+        self.assertEqual(classification.skip_reason, "POST-only view")
+        self.assertFalse(classification.should_resolve)
+
+    def test_classification_marks_missing_docs_dependency(self):
+        normalized = _normalize_admin_route(
+            _DiscoveredAdminRoute(
+                raw_route="admin/documents/<int:document_id>/edit/",
+                name="edit",
+                namespace="wagtaildocs",
+                callback=lambda request: None,
+            ),
+            skip_prefixes=[],
+        )
+
+        classification = _classify_admin_route(
+            normalized,
+            docs_serve_available=False,
+            images_serve_available=True,
+        )
+
+        self.assertFalse(classification.is_testable)
+        self.assertIn("wagtaildocs_urls", classification.skip_reason)
+        self.assertFalse(classification.should_resolve)
+
+    def test_parameterized_routes_require_resolution_before_skip_reason(self):
+        normalized = _normalize_admin_route(
+            _DiscoveredAdminRoute(
+                raw_route="admin/images/<int:image_id>/edit/",
+                name="edit",
+                namespace="wagtailimages",
+                callback=lambda request: None,
+            ),
+            skip_prefixes=[],
+        )
+
+        classification = _classify_admin_route(
+            normalized,
+            docs_serve_available=True,
+            images_serve_available=True,
+        )
+
+        self.assertTrue(classification.is_testable)
+        self.assertTrue(classification.should_resolve)
+        self.assertEqual(classification.skip_reason, "")
+
+    def test_finalization_assigns_parameter_skip_reason_after_failed_resolution(self):
+        normalized = _normalize_admin_route(
+            _DiscoveredAdminRoute(
+                raw_route="admin/images/<int:image_id>/edit/",
+                name="edit",
+                namespace="wagtailimages",
+                callback=lambda request: None,
+            ),
+            skip_prefixes=[],
+        )
+        classification = _AdminClassification(should_resolve=True)
+
+        with mock.patch(
+            "wagtail_unveil.discovery.backend._resolve_parameterized_url",
+            return_value=mock.Mock(resolved=False, resolved_route=""),
+        ):
+            result = _finalize_admin_route(normalized, classification)
+
+        self.assertFalse(result.is_testable)
+        self.assertEqual(result.skip_reason, "URL requires parameters")
+        self.assertEqual(result.resolved_route, "")
 
 
 class TestParameterisedURLResolution(TestCase):

--- a/tests/test_frontend_urls.py
+++ b/tests/test_frontend_urls.py
@@ -2,7 +2,13 @@ from django.test import TestCase
 from wagtail.models import Page
 
 from sandbox.events.models import EventIndexPage
-from wagtail_unveil.discovery.frontend import FrontendURL, get_frontend_urls
+from wagtail_unveil.discovery.frontend import (
+    FrontendURL,
+    _build_frontend_url,
+    _classify_frontend_candidate,
+    _FrontendCandidate,
+    get_frontend_urls,
+)
 
 
 class TestGetFrontendUrls(TestCase):
@@ -130,3 +136,65 @@ class TestRoutableSubUrls(TestCase):
             self.assertEqual(url.page_type, self.page_type)
             self.assertEqual(url.page_title, "Events")
             self.assertTrue(url.name)
+
+
+class TestFrontendDiscoveryPhases(TestCase):
+    def test_plain_page_candidate_is_testable(self):
+        candidate = _FrontendCandidate(
+            url="/about/",
+            source="page",
+            page_type="core.StandardPage",
+            page_title="About",
+            name="",
+        )
+
+        classification = _classify_frontend_candidate(candidate)
+        result = _build_frontend_url(candidate, classification)
+
+        self.assertTrue(result.is_testable)
+        self.assertEqual(result.skip_reason, "")
+
+    def test_form_landing_candidate_requires_post(self):
+        candidate = _FrontendCandidate(
+            url="/contact/",
+            source="page",
+            page_type="forms.FormPage",
+            page_title="Contact",
+            name="landing_page",
+            requires_post=True,
+        )
+
+        classification = _classify_frontend_candidate(candidate)
+
+        self.assertFalse(classification.is_testable)
+        self.assertEqual(classification.skip_reason, "Requires POST submission")
+
+    def test_parameterized_routable_candidate_requires_parameters(self):
+        candidate = _FrontendCandidate(
+            url="/events/year/<int:year>/",
+            source="page",
+            page_type="events.EventIndexPage",
+            page_title="Events",
+            name="events_for_year",
+            has_parameters=True,
+        )
+
+        classification = _classify_frontend_candidate(candidate)
+
+        self.assertFalse(classification.is_testable)
+        self.assertEqual(classification.skip_reason, "URL requires parameters")
+
+    def test_regex_resolver_candidate_is_marked_untestable(self):
+        candidate = _FrontendCandidate(
+            url="/documents/(.*)/",
+            source="resolver",
+            page_type="",
+            page_title="",
+            name="wagtaildocs_serve",
+            contains_regex=True,
+        )
+
+        classification = _classify_frontend_candidate(candidate)
+
+        self.assertFalse(classification.is_testable)
+        self.assertEqual(classification.skip_reason, "URL contains regex patterns")

--- a/wagtail_unveil/AGENTS.md
+++ b/wagtail_unveil/AGENTS.md
@@ -71,7 +71,7 @@ The full discovery flow, resolution fallbacks, special cases, and intentional li
 
 ### Admin URLs
 
-`get_admin_urls()` walks Django URL patterns, filters admin routes, and resolves parameterized URLs using an explicit strategy order: settings, callback model inference, modeladmin name parsing, namespace-specific instance fallbacks, then reverse.
+`get_admin_urls()` follows explicit phases: discover admin candidates, normalize route metadata, classify testability, resolve supported parameterized URLs, then emit `BackendURL` objects.
 Namespace-specific rules may replace an earlier instance choice or invalidate it entirely when the route requires a different model type, such as workflow usage URLs.
 
 ### Frontend URLs
@@ -82,7 +82,7 @@ Namespace-specific rules may replace an earlier instance choice or invalidate it
 - additional page-derived routes for forms and `RoutablePageMixin`
 - non-admin resolver routes
 
-Parameterized routable sub-routes are discovered but marked non-testable.
+Frontend discovery also follows explicit phases: discover candidates, normalize route metadata, classify testability, then emit `FrontendURL` objects. Parameterized routable sub-routes are discovered but marked non-testable during classification.
 
 ## Constraints
 

--- a/wagtail_unveil/discovery/backend.py
+++ b/wagtail_unveil/discovery/backend.py
@@ -6,7 +6,7 @@ from django.apps import apps
 from django.urls import get_resolver, reverse
 from django.utils.functional import cached_property as django_cached_property
 
-from wagtail_unveil.discovery.utils import clean_regex_route, walk_patterns
+from wagtail_unveil.discovery.utils import clean_regex_route, route_has_parameters, walk_patterns
 from wagtail_unveil.settings import get_skip_url_prefixes
 
 
@@ -30,6 +30,31 @@ class BackendURL:
     is_testable: bool = True
     skip_reason: str = ""
     resolved_route: str = ""
+
+
+@dataclass
+class _DiscoveredAdminRoute:
+    raw_route: str
+    name: str
+    namespace: str
+    callback: object
+
+
+@dataclass
+class _NormalizedAdminRoute:
+    route: str
+    name: str
+    namespace: str
+    callback: object
+    has_parameters: bool
+    view_name: str
+
+
+@dataclass
+class _AdminClassification:
+    is_testable: bool = True
+    skip_reason: str = ""
+    should_resolve: bool = False
 
 
 @dataclass
@@ -57,6 +82,24 @@ def _get_view_name(callback):
 
 
 WORKFLOW_USAGE_NAMES = ("usage", "usage_results")
+NON_TESTABLE_NAMES = {
+    "wagtailadmin_logout": "POST-only view",
+    "wagtailadmin_error_test": "Intentional error endpoint",
+    "process_import": "POST-only view",
+    "wagtailadmin_block_preview": "POST-only view",
+    "lock": "POST-only view",
+    "unlock": "POST-only view",
+    "find": "Requires query parameters",
+}
+DOCS_SERVE_NAMESPACES = {
+    "wagtaildocs",
+    "wagtaildocs_chooser",
+    "wagtailadmin_api:documents",
+}
+IMAGE_GENERATOR_NAMES = {
+    "url_generator",
+    "url_generator_output",
+}
 NAMESPACE_INSTANCE_RESOLVERS = (
     {
         "label": "namespace:wagtailforms",
@@ -192,6 +235,102 @@ def _reverse_with_instance(namespace, name, instance):
     result.resolved_route = url.lstrip("/")
     result.detail = f"Reversed {_build_url_name(namespace, name)} with pk={instance.pk}"
     return result
+
+
+def _discover_admin_routes():
+    """Return raw admin routes discovered from the resolver."""
+    resolver = get_resolver()
+    results = []
+    for route, name, namespace, callback in walk_patterns(resolver.url_patterns):
+        if route.startswith("admin/"):
+            results.append(
+                _DiscoveredAdminRoute(
+                    raw_route=route,
+                    name=name,
+                    namespace=namespace,
+                    callback=callback,
+                )
+            )
+    return results
+
+
+def _has_unsafe_admin_regex(route):
+    """Return True when a cleaned admin route still contains unsafe regex syntax."""
+    return bool(re.search(r"[.][*+?]|\(", route))
+
+
+def _normalize_admin_route(discovered_route, skip_prefixes):
+    """Normalize a raw admin route and filter unsupported patterns."""
+    route = clean_regex_route(discovered_route.raw_route)
+    if _has_unsafe_admin_regex(route):
+        return None
+    if skip_prefixes and any(route.startswith(prefix) for prefix in skip_prefixes):
+        return None
+    return _NormalizedAdminRoute(
+        route=route,
+        name=discovered_route.name,
+        namespace=discovered_route.namespace,
+        callback=discovered_route.callback,
+        has_parameters=route_has_parameters(route),
+        view_name=_get_view_name(discovered_route.callback),
+    )
+
+
+def _classify_admin_route(normalized_route, docs_serve_available, images_serve_available):
+    """Classify a normalized admin route before parameter resolution."""
+    if normalized_route.name in NON_TESTABLE_NAMES:
+        return _AdminClassification(
+            is_testable=False,
+            skip_reason=NON_TESTABLE_NAMES[normalized_route.name],
+        )
+    if not docs_serve_available and normalized_route.namespace in DOCS_SERVE_NAMESPACES:
+        return _AdminClassification(
+            is_testable=False,
+            skip_reason='Requires path("documents/", include(wagtaildocs_urls)) in URLconf',
+        )
+    if (
+        not images_serve_available
+        and normalized_route.namespace == "wagtailimages"
+        and normalized_route.name in IMAGE_GENERATOR_NAMES
+    ):
+        return _AdminClassification(
+            is_testable=False,
+            skip_reason='Requires path("images/", include(wagtailimages_urls)) in URLconf',
+        )
+    if normalized_route.has_parameters:
+        return _AdminClassification(should_resolve=True)
+    return _AdminClassification()
+
+
+def _finalize_admin_route(normalized_route, classification):
+    """Emit the final BackendURL from normalized and classified state."""
+    resolved_route = ""
+    is_testable = classification.is_testable
+    skip_reason = classification.skip_reason
+
+    if classification.should_resolve:
+        resolution = _resolve_parameterized_url(
+            normalized_route.namespace,
+            normalized_route.name,
+            normalized_route.callback,
+            normalized_route.route,
+        )
+        if resolution.resolved:
+            resolved_route = resolution.resolved_route
+        else:
+            is_testable = False
+            skip_reason = "URL requires parameters"
+
+    return BackendURL(
+        route=normalized_route.route,
+        name=normalized_route.name,
+        namespace=normalized_route.namespace,
+        has_parameters=normalized_route.has_parameters,
+        view_name=normalized_route.view_name,
+        is_testable=is_testable,
+        skip_reason=skip_reason,
+        resolved_route=resolved_route,
+    )
 
 
 def _resolve_settings_url(name, route):
@@ -395,80 +534,18 @@ def get_admin_urls():
     Returns a list of BackendURL dataclass instances for every URL pattern
     under the admin/ prefix.
     """
-    # URL names that are known to be non-testable via GET.
-    NON_TESTABLE_NAMES = {
-        "wagtailadmin_logout": "POST-only view",
-        "wagtailadmin_error_test": "Intentional error endpoint",
-        "process_import": "POST-only view",
-        "wagtailadmin_block_preview": "POST-only view",
-        "lock": "POST-only view",
-        "unlock": "POST-only view",
-        "find": "Requires query parameters",
-    }
-
     images_serve_available = _is_url_registered("wagtailimages_serve")
     docs_serve_available = _is_url_registered("wagtaildocs_serve")
-
-    resolver = get_resolver()
     skip_prefixes = get_skip_url_prefixes()
     results = []
-    for route, name, namespace, callback in walk_patterns(resolver.url_patterns):
-        if not route.startswith("admin/"):
+    for discovered_route in _discover_admin_routes():
+        normalized_route = _normalize_admin_route(discovered_route, skip_prefixes)
+        if normalized_route is None:
             continue
-        route = clean_regex_route(route)
-
-        # Skip routes that still contain regex metacharacters after cleaning
-        # (e.g. Wagtail's catch-all `.*/$` pattern)
-        if re.search(r"[.][*+?]|\(", route):
-            continue
-
-        # User-configured prefix exclusions
-        if skip_prefixes and any(route.startswith(p) for p in skip_prefixes):
-            continue
-
-        has_parameters = "<" in route
-        is_testable = True
-        skip_reason = ""
-        resolved_route = ""
-        if name in NON_TESTABLE_NAMES:
-            is_testable = False
-            skip_reason = NON_TESTABLE_NAMES[name]
-        elif not docs_serve_available and namespace in {
-            "wagtaildocs",
-            "wagtaildocs_chooser",
-            "wagtailadmin_api:documents",
-        }:
-            is_testable = False
-            skip_reason = 'Requires path("documents/", include(wagtaildocs_urls)) in URLconf'
-        elif (
-            not images_serve_available
-            and namespace == "wagtailimages"
-            and name
-            in {
-                "url_generator",
-                "url_generator_output",
-            }
-        ):
-            is_testable = False
-            skip_reason = 'Requires path("images/", include(wagtailimages_urls)) in URLconf'
-        elif has_parameters:
-            resolution = _resolve_parameterized_url(namespace, name, callback, route)
-            if resolution.resolved:
-                is_testable = True
-                resolved_route = resolution.resolved_route
-            else:
-                is_testable = False
-                skip_reason = "URL requires parameters"
-        results.append(
-            BackendURL(
-                route=route,
-                name=name,
-                namespace=namespace,
-                has_parameters=has_parameters,
-                view_name=_get_view_name(callback),
-                is_testable=is_testable,
-                skip_reason=skip_reason,
-                resolved_route=resolved_route,
-            )
+        classification = _classify_admin_route(
+            normalized_route,
+            docs_serve_available=docs_serve_available,
+            images_serve_available=images_serve_available,
         )
+        results.append(_finalize_admin_route(normalized_route, classification))
     return results

--- a/wagtail_unveil/discovery/frontend.py
+++ b/wagtail_unveil/discovery/frontend.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 from django.urls import get_resolver
 
-from wagtail_unveil.discovery.utils import clean_regex_route, walk_patterns
+from wagtail_unveil.discovery.utils import clean_regex_route, route_contains_regex, route_has_parameters, walk_patterns
 from wagtail_unveil.settings import get_pages_per_type, get_skip_url_prefixes
 
 
@@ -19,15 +19,31 @@ class FrontendURL:
     skip_reason: str = ""
 
 
-def _get_page_urls():
-    """Discover frontend URLs from live Wagtail pages.
+@dataclass
+class _FrontendCandidate:
+    url: str
+    source: str
+    page_type: str
+    page_title: str
+    name: str
+    has_parameters: bool = False
+    contains_regex: bool = False
+    requires_post: bool = False
 
-    Uses Page.objects.live().specific() to get all live pages, returning
-    their .url property. Skips the root Page model and pages without a URL.
-    Form pages (FormMixin subclasses) also get a second non-testable entry
-    for the landing page (POST response). RoutablePageMixin pages also get
-    entries for each sub-route defined via @path() decorators.
-    """
+
+@dataclass
+class _FrontendClassification:
+    is_testable: bool = True
+    skip_reason: str = ""
+
+
+def _should_skip_frontend_url(url, skip_prefixes):
+    """Return True when a frontend URL matches configured skip prefixes."""
+    return bool(skip_prefixes and any(url.lstrip("/").startswith(prefix) for prefix in skip_prefixes))
+
+
+def _discover_page_candidates():
+    """Discover frontend page candidates before classification."""
     try:
         from wagtail.contrib.forms.models import FormMixin
     except ImportError:
@@ -44,7 +60,6 @@ def _get_page_urls():
     results = []
     pages = Page.objects.live().specific()
     for page in pages:
-        # Skip the base Page model (depth 1 is the abstract root)
         if type(page) is Page:
             continue
         try:
@@ -53,14 +68,13 @@ def _get_page_urls():
             url = None
         if not url:
             continue
-        # Strip to path-only for multi-site support
         parsed = urlparse(url)
         path = parsed.path
-        if skip_prefixes and any(path.lstrip("/").startswith(p) for p in skip_prefixes):
+        if _should_skip_frontend_url(path, skip_prefixes):
             continue
         page_type = f"{page._meta.app_label}.{type(page).__name__}"
         results.append(
-            FrontendURL(
+            _FrontendCandidate(
                 url=path,
                 source="page",
                 page_type=page_type,
@@ -70,50 +84,25 @@ def _get_page_urls():
         )
         if FormMixin is not None and isinstance(page, FormMixin):
             results.append(
-                FrontendURL(
+                _FrontendCandidate(
                     url=path,
                     source="page",
                     page_type=page_type,
                     page_title=page.title,
                     name="landing_page",
-                    is_testable=False,
-                    skip_reason="Requires POST submission",
+                    requires_post=True,
                 )
             )
-        # Discover sub-routes from RoutablePageMixin pages
         if RoutablePageMixin is not None and isinstance(page, RoutablePageMixin):
-            for sub_url_entry in _get_routable_sub_urls(page, path, page_type, skip_prefixes):
-                results.append(sub_url_entry)
+            results.extend(_discover_routable_page_candidates(page, path, page_type, skip_prefixes))
 
-    limit = get_pages_per_type()
-    if limit:
-        # Group URLs by page (type + title), then limit to N pages per type.
-        # Each page may have multiple URL entries (sub-routes, landing pages).
-        page_urls = defaultdict(list)
-        for frontend_url in results:
-            key = (frontend_url.page_type, frontend_url.page_title)
-            page_urls[key].append(frontend_url)
-        # Group pages by type and take up to `limit` pages per type
-        type_pages = defaultdict(list)
-        for (page_type, _title), urls in page_urls.items():
-            type_pages[page_type].append(urls)
-        results = []
-        for pages_in_type in type_pages.values():
-            for page_entries in pages_in_type[:limit]:
-                results.extend(page_entries)
-
-    return results
+    return _apply_page_limit(results)
 
 
-def _get_routable_sub_urls(page, page_path, page_type, skip_prefixes=()):
-    """Discover sub-route URLs from a RoutablePageMixin page.
-
-    Inspects the page class's subpage_urls to find @path() decorated routes,
-    and builds FrontendURL entries for each non-index sub-route.
-    """
+def _discover_routable_page_candidates(page, page_path, page_type, skip_prefixes=()):
+    """Discover routable page candidates before classification."""
     results = []
     for pattern in type(page).get_subpage_urls():
-        # Extract the route string from the URL pattern
         if hasattr(pattern.pattern, "_route"):
             sub_route = pattern.pattern._route
         elif hasattr(pattern.pattern, "_regex"):
@@ -121,87 +110,109 @@ def _get_routable_sub_urls(page, page_path, page_type, skip_prefixes=()):
         else:
             continue
 
-        # Skip the index route (empty string) — already covered by base page URL
         if not sub_route:
             continue
 
         full_url = page_path.rstrip("/") + "/" + sub_route.lstrip("/")
-        if skip_prefixes and any(full_url.lstrip("/").startswith(p) for p in skip_prefixes):
+        if _should_skip_frontend_url(full_url, skip_prefixes):
             continue
-        has_parameters = "<" in sub_route
-        if has_parameters:
-            results.append(
-                FrontendURL(
-                    url=full_url,
-                    source="page",
-                    page_type=page_type,
-                    page_title=page.title,
-                    name=pattern.name or "",
-                    is_testable=False,
-                    skip_reason="URL requires parameters",
-                )
+        results.append(
+            _FrontendCandidate(
+                url=full_url,
+                source="page",
+                page_type=page_type,
+                page_title=page.title,
+                name=pattern.name or "",
+                has_parameters=route_has_parameters(sub_route),
             )
-        else:
-            results.append(
-                FrontendURL(
-                    url=full_url,
-                    source="page",
-                    page_type=page_type,
-                    page_title=page.title,
-                    name=pattern.name or "",
-                )
-            )
+        )
     return results
 
 
-def _get_resolver_frontend_urls():
-    """Discover frontend URLs from Django's URL resolver (non-admin routes).
+def _apply_page_limit(candidates):
+    """Apply the configured per-page-type limit while keeping page entries together."""
+    limit = get_pages_per_type()
+    if not limit:
+        return candidates
 
-    Reuses walk_patterns() but excludes admin/ routes and unveil's own
-    namespaces. Parameterized and regex URLs are marked as non-testable.
-    """
+    page_urls = defaultdict(list)
+    for candidate in candidates:
+        key = (candidate.page_type, candidate.page_title)
+        page_urls[key].append(candidate)
+
+    type_pages = defaultdict(list)
+    for (page_type, _title), urls in page_urls.items():
+        type_pages[page_type].append(urls)
+
+    limited = []
+    for pages_in_type in type_pages.values():
+        for page_entries in pages_in_type[:limit]:
+            limited.extend(page_entries)
+    return limited
+
+
+def _discover_resolver_candidates():
+    """Discover resolver-backed frontend candidates before classification."""
     resolver = get_resolver()
     skip_prefixes = get_skip_url_prefixes()
     results = []
     for route, name, namespace, _callback in walk_patterns(resolver.url_patterns):
-        # Exclude admin routes
         if route.startswith("admin/"):
             continue
-        # Exclude Django admin
         if route.startswith("django-admin/"):
             continue
-        # Exclude unveil's own namespaces
         if namespace == "wagtail_unveil":
             continue
-        # User-configured prefix exclusions
-        if skip_prefixes and any(route.startswith(p) for p in skip_prefixes):
+        if skip_prefixes and any(route.startswith(prefix) for prefix in skip_prefixes):
             continue
 
-        route = clean_regex_route(route)
-        is_testable = True
-        skip_reason = ""
-
-        # Parameterized URLs are not directly testable
-        if "<" in route:
-            is_testable = False
-            skip_reason = "URL requires parameters"
-        elif "(" in route:
-            is_testable = False
-            skip_reason = "URL contains regex patterns"
-
-        url = f"/{route}" if not route.startswith("/") else route
+        normalized_route = clean_regex_route(route)
+        url = normalized_route if normalized_route.startswith("/") else f"/{normalized_route}"
         results.append(
-            FrontendURL(
+            _FrontendCandidate(
                 url=url,
                 source="resolver",
                 page_type="",
                 page_title="",
                 name=name,
-                is_testable=is_testable,
-                skip_reason=skip_reason,
+                has_parameters=route_has_parameters(normalized_route),
+                contains_regex=route_contains_regex(normalized_route),
             )
         )
     return results
+
+
+def _classify_frontend_candidate(candidate):
+    """Classify a frontend candidate and assign any skip reason."""
+    if candidate.requires_post:
+        return _FrontendClassification(
+            is_testable=False,
+            skip_reason="Requires POST submission",
+        )
+    if candidate.has_parameters:
+        return _FrontendClassification(
+            is_testable=False,
+            skip_reason="URL requires parameters",
+        )
+    if candidate.contains_regex:
+        return _FrontendClassification(
+            is_testable=False,
+            skip_reason="URL contains regex patterns",
+        )
+    return _FrontendClassification()
+
+
+def _build_frontend_url(candidate, classification):
+    """Emit a FrontendURL from candidate and classification state."""
+    return FrontendURL(
+        url=candidate.url,
+        source=candidate.source,
+        page_type=candidate.page_type,
+        page_title=candidate.page_title,
+        name=candidate.name,
+        is_testable=classification.is_testable,
+        skip_reason=classification.skip_reason,
+    )
 
 
 def get_frontend_urls():
@@ -210,4 +221,9 @@ def get_frontend_urls():
     Returns a list of FrontendURL dataclass instances combining page URLs
     and non-admin resolver URLs.
     """
-    return _get_page_urls() + _get_resolver_frontend_urls()
+    results = []
+    candidates = _discover_page_candidates() + _discover_resolver_candidates()
+    for candidate in candidates:
+        classification = _classify_frontend_candidate(candidate)
+        results.append(_build_frontend_url(candidate, classification))
+    return results

--- a/wagtail_unveil/discovery/utils.py
+++ b/wagtail_unveil/discovery/utils.py
@@ -25,3 +25,13 @@ def clean_regex_route(route):
     route = route.replace("^", "").replace("$", "")
     route = re.sub(r"\(\?P<(\w+)>[^)]+\)", r"<\1>", route)
     return route
+
+
+def route_has_parameters(route):
+    """Return True when a normalized route still contains path parameters."""
+    return "<" in route
+
+
+def route_contains_regex(route):
+    """Return True when a normalized route still contains regex syntax."""
+    return "(" in route


### PR DESCRIPTION
## Summary
- refactor admin discovery into explicit discover, normalize, classify, resolve, and emit phases
- refactor frontend discovery into explicit discover, normalize, classify, and emit phases
- preserve the backend parameter-resolution pipeline already introduced on the base branch
- update discovery architecture docs and add phase-boundary tests

## Notes
- this PR is based on `codex/issue-12-admin-url-resolution` and is intended to be reviewed on top of that branch
- public discovery outputs remain unchanged apart from the admin resolution improvements already present in the base branch

## Verification
- `make lint`
- `make coverage`

Refs #11