### PR TITLE
Version the JSON API contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,8 @@ path("unveil/", include("wagtail_unveil.urls"))
 
 Routes provided:
 
-- `api/backend-urls/` → `wagtail_unveil:api_backend_urls`
-- `api/frontend-urls/` → `wagtail_unveil:api_frontend_urls`
+- `api/v1/backend-urls/` → `wagtail_unveil:api_v1_backend_urls`
+- `api/v1/frontend-urls/` → `wagtail_unveil:api_v1_frontend_urls`
 - `report/backend-urls/` → `wagtail_unveil:report_backend_urls`
 - `report/frontend-urls/` → `wagtail_unveil:report_frontend_urls`
 

--- a/README.md
+++ b/README.md
@@ -74,13 +74,14 @@ Set `WAGTAIL_UNVEIL_API_KEY` via environment variable (recommended) or Django se
 If both are set, the environment variable takes precedence.
 
 ```bash
-curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/backend-urls/
-curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/frontend-urls/
+curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/v1/backend-urls/
+curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/v1/frontend-urls/
 ```
 
 Filter with `?filter=static`, `?filter=parameterized`, `?filter=pages`, or `?filter=resolver`.
 Responses keep the existing top-level `urls` and `count` fields and also include a `metadata` object with:
 
+- `api_version`
 - `generated_at`
 - `applied_filter`
 - `total_count`
@@ -88,7 +89,11 @@ Responses keep the existing top-level `urls` and `count` fields and also include
 - `untestable_count`
 - `package_version`
 
-For the built-in HTML reports, the same endpoints also accept a logged-in superuser session when `DEBUG=True` and the request is not attempting Bearer-token auth.
+`api_version` describes the response contract version. `package_version` describes the installed `wagtail-unveil` release and is not the API version.
+
+Breaking API changes should ship under a new versioned path such as `/unveil/api/v2/...`.
+
+For the built-in HTML reports, the same versioned endpoints also accept a logged-in superuser session when `DEBUG=True` and the request is not attempting Bearer-token auth. The HTML reports are consumers of the JSON API, not a separate API contract.
 
 For full API response examples and detailed feature documentation, see [docs/usage.md](docs/usage.md).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -43,13 +43,13 @@ so `"/__debug__/"` and `"__debug__/"` are equivalent. Invalid values are silentl
 
 ```bash
 # All admin URLs
-curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/backend-urls/
+curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/v1/backend-urls/
 
 # Static URLs only
-curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/api/backend-urls/?filter=static"
+curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/api/v1/backend-urls/?filter=static"
 
 # Parameterized URLs only
-curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/api/backend-urls/?filter=parameterized"
+curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/api/v1/backend-urls/?filter=parameterized"
 ```
 
 **Response:**
@@ -67,12 +67,13 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
   ],
   "count": 190,
   "metadata": {
+    "api_version": "v1",
     "generated_at": "2026-03-02T12:34:56+00:00",
     "applied_filter": null,
     "total_count": 190,
     "testable_count": 150,
     "untestable_count": 40,
-    "package_version": "0.1.0"
+    "package_version": "0.2.0"
   }
 }
 ```
@@ -81,13 +82,13 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
 
 ```bash
 # All frontend URLs
-curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/frontend-urls/
+curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/v1/frontend-urls/
 
 # Page URLs only
-curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/api/frontend-urls/?filter=pages"
+curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/api/v1/frontend-urls/?filter=pages"
 
 # Resolver URLs only
-curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/api/frontend-urls/?filter=resolver"
+curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/api/v1/frontend-urls/?filter=resolver"
 ```
 
 ### Authentication
@@ -96,19 +97,22 @@ The API accepts a Bearer token matching `WAGTAIL_UNVEIL_API_KEY` (from environme
 If both are set, environment is used. Requests with an invalid key receive a `403` response.
 If no key is configured in either place, Bearer-authenticated requests return `500`.
 
-When `DEBUG=True`, the built-in HTML reports fetch the same endpoints using the current logged-in superuser session.
+When `DEBUG=True`, the built-in HTML reports fetch the same versioned endpoints using the current logged-in superuser session.
 That session-based access is accepted when the request is not attempting Bearer-token auth.
 
 ### Metadata
 
 Both JSON endpoints include a `metadata` object alongside the existing top-level `urls` and `count` fields.
 
+- `api_version` — response contract version, currently `v1`
 - `generated_at` — ISO 8601 timestamp for when the response was generated
 - `applied_filter` — the recognised `filter` value that was applied, or `null`
 - `total_count` — total URLs returned in the response
 - `testable_count` — number of URLs marked testable
 - `untestable_count` — number of URLs marked untestable
-- `package_version` — installed `wagtail-unveil` package version
+- `package_version` — installed `wagtail-unveil` package version, not the API version
+
+Breaking API changes should ship under a new versioned path such as `/unveil/api/v2/...`.
 
 ## HTML Reports
 
@@ -117,7 +121,7 @@ Both JSON endpoints include a `metadata` object alongside the existing top-level
 The report URLs are included automatically when you add `wagtail_unveil.urls` (see JSON API → Setup above).
 
 Reports require **superuser login** and **`DEBUG=True`**.
-The HTML page then fetches its data from the matching JSON endpoint using the current session.
+The HTML page then fetches its data from the matching versioned JSON endpoint using the current session.
 JavaScript is required, and the report stays behind a full-screen loading state until the data and UI controls are ready.
 
 ### Admin URLs Report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wagtail-unveil"
-version = "0.1.0"
+version = "0.2.0"
 description = "Discover and test all URLs in your Wagtail site — frontend and admin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -14,11 +14,11 @@ from wagtail_unveil.wagtail_hooks import UnveilReportPanel
 
 @patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"})
 class TestAdminUrlsAPIView(BaseAPIViewTestMixin, TestCase):
-    api_url = "/unveil/api/backend-urls/"
+    api_url = "/unveil/api/v1/backend-urls/"
 
     def test_filter_static(self):
         response = self.client.get(
-            "/unveil/api/backend-urls/?filter=static",
+            "/unveil/api/v1/backend-urls/?filter=static",
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         data = response.json()
@@ -29,7 +29,7 @@ class TestAdminUrlsAPIView(BaseAPIViewTestMixin, TestCase):
 
     def test_filter_parameterized(self):
         response = self.client.get(
-            "/unveil/api/backend-urls/?filter=parameterized",
+            "/unveil/api/v1/backend-urls/?filter=parameterized",
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         data = response.json()
@@ -40,10 +40,17 @@ class TestAdminUrlsAPIView(BaseAPIViewTestMixin, TestCase):
 
     def test_invalid_filter_does_not_apply_metadata_filter(self):
         response = self.client.get(
-            "/unveil/api/backend-urls/?filter=unknown",
+            "/unveil/api/v1/backend-urls/?filter=unknown",
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         self.assertIsNone(response.json()["metadata"]["applied_filter"])
+
+    def test_response_includes_api_version_metadata(self):
+        response = self.client.get(
+            "/unveil/api/v1/backend-urls/",
+            HTTP_AUTHORIZATION="Bearer test-secret",
+        )
+        self.assertEqual(response.json()["metadata"]["api_version"], "v1")
 
 
 class TestAdminAPIViewHelpers(TestCase):
@@ -53,7 +60,7 @@ class TestAdminAPIViewHelpers(TestCase):
     @patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"})
     def test_authenticate_api_request_accepts_matching_bearer_token(self):
         request = self.factory.get(
-            "/unveil/api/backend-urls/",
+            "/unveil/api/v1/backend-urls/",
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         self.assertIsNone(_authenticate_api_request(request))
@@ -61,7 +68,7 @@ class TestAdminAPIViewHelpers(TestCase):
     @patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"})
     def test_authenticate_api_request_rejects_wrong_bearer_token(self):
         request = self.factory.get(
-            "/unveil/api/backend-urls/",
+            "/unveil/api/v1/backend-urls/",
             HTTP_AUTHORIZATION="Bearer wrong-key",
         )
         response = _authenticate_api_request(request)
@@ -74,7 +81,7 @@ class TestAdminAPIViewHelpers(TestCase):
     @override_settings(DEBUG=False)
     def test_authenticate_api_request_rejects_non_bearer_header_without_api_key(self):
         request = self.factory.get(
-            "/unveil/api/backend-urls/",
+            "/unveil/api/v1/backend-urls/",
             HTTP_AUTHORIZATION="Basic abc123",
         )
         response = _authenticate_api_request(request)
@@ -125,7 +132,7 @@ class TestAdminUrlsReportView(BaseReportViewTestMixin, WagtailTestUtils, TestCas
 
     def test_report_includes_backend_api_url(self):
         response = self.client.get("/unveil/report/backend-urls/")
-        self.assertContains(response, 'data-api-url="/unveil/api/backend-urls/"')
+        self.assertContains(response, 'data-api-url="/unveil/api/v1/backend-urls/"')
 
     def test_report_uses_summary_placeholders(self):
         response = self.client.get("/unveil/report/backend-urls/")

--- a/tests/test_frontend_views.py
+++ b/tests/test_frontend_views.py
@@ -12,11 +12,11 @@ from wagtail_unveil.wagtail_hooks import UnveilReportPanel
 
 @patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"})
 class TestFrontendUrlsAPIView(BaseAPIViewTestMixin, TestCase):
-    api_url = "/unveil/api/frontend-urls/"
+    api_url = "/unveil/api/v1/frontend-urls/"
 
     def test_filter_pages(self):
         response = self.client.get(
-            "/unveil/api/frontend-urls/?filter=pages",
+            "/unveil/api/v1/frontend-urls/?filter=pages",
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         data = response.json()
@@ -27,7 +27,7 @@ class TestFrontendUrlsAPIView(BaseAPIViewTestMixin, TestCase):
 
     def test_filter_resolver(self):
         response = self.client.get(
-            "/unveil/api/frontend-urls/?filter=resolver",
+            "/unveil/api/v1/frontend-urls/?filter=resolver",
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         data = response.json()
@@ -38,10 +38,17 @@ class TestFrontendUrlsAPIView(BaseAPIViewTestMixin, TestCase):
 
     def test_invalid_filter_does_not_apply_metadata_filter(self):
         response = self.client.get(
-            "/unveil/api/frontend-urls/?filter=unknown",
+            "/unveil/api/v1/frontend-urls/?filter=unknown",
             HTTP_AUTHORIZATION="Bearer test-secret",
         )
         self.assertIsNone(response.json()["metadata"]["applied_filter"])
+
+    def test_response_includes_api_version_metadata(self):
+        response = self.client.get(
+            "/unveil/api/v1/frontend-urls/",
+            HTTP_AUTHORIZATION="Bearer test-secret",
+        )
+        self.assertEqual(response.json()["metadata"]["api_version"], "v1")
 
 
 class TestFrontendAPIViewHelpers(TestCase):
@@ -93,7 +100,7 @@ class TestFrontendUrlsReportView(BaseReportViewTestMixin, WagtailTestUtils, Test
 
     def test_report_includes_frontend_api_url(self):
         response = self.client.get("/unveil/report/frontend-urls/")
-        self.assertContains(response, 'data-api-url="/unveil/api/frontend-urls/"')
+        self.assertContains(response, 'data-api-url="/unveil/api/v1/frontend-urls/"')
 
     def test_report_does_not_render_rows_server_side(self):
         response = self.client.get("/unveil/report/frontend-urls/")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,6 +35,7 @@ class BaseAPIViewTestMixin:
         )
 
         metadata = response.json()["metadata"]
+        self.assertEqual(metadata["api_version"], "v1")
         self.assertEqual(metadata["generated_at"], "2026-03-02T12:34:56+00:00")
         self.assertIsNone(metadata["applied_filter"])
         self.assertEqual(metadata["package_version"], "9.9.9")

--- a/uv.lock
+++ b/uv.lock
@@ -1103,7 +1103,7 @@ wheels = [
 
 [[package]]
 name = "wagtail-unveil"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },

--- a/wagtail_unveil/AGENTS.md
+++ b/wagtail_unveil/AGENTS.md
@@ -48,8 +48,8 @@ JSON API requests also allow superuser session auth when `DEBUG=True` and the re
 
 The package exports one URL namespace:
 
-- `wagtail_unveil:api_backend_urls`
-- `wagtail_unveil:api_frontend_urls`
+- `wagtail_unveil:api_v1_backend_urls`
+- `wagtail_unveil:api_v1_frontend_urls`
 - `wagtail_unveil:report_backend_urls`
 - `wagtail_unveil:report_frontend_urls`
 
@@ -59,12 +59,16 @@ Do not document or reintroduce the old split `api_urls.py` / `report_urls.py` na
 
 JSON API endpoints preserve top-level `urls` and `count` fields and also return a `metadata` object containing:
 
+- `api_version`
 - `generated_at`
 - `applied_filter`
 - `total_count`
 - `testable_count`
 - `untestable_count`
 - `package_version`
+
+`api_version` identifies the response contract version. `package_version` identifies the installed package release and is not the API version.
+Breaking API changes should use a new versioned path such as `/api/v2/...`.
 
 The HTML reports are shell views that fetch this JSON on page load rather than rendering discovery results directly in the Django template. They stay hidden behind a full-screen loading state until the API data and client-side controls are ready, so JavaScript is required for report use.
 

--- a/wagtail_unveil/urls.py
+++ b/wagtail_unveil/urls.py
@@ -5,8 +5,8 @@ from wagtail_unveil.views import admin_urls_json, admin_urls_report, frontend_ur
 app_name = "wagtail_unveil"
 
 urlpatterns = [
-    path("api/backend-urls/", admin_urls_json, name="api_backend_urls"),
-    path("api/frontend-urls/", frontend_urls_json, name="api_frontend_urls"),
+    path("api/v1/backend-urls/", admin_urls_json, name="api_v1_backend_urls"),
+    path("api/v1/frontend-urls/", frontend_urls_json, name="api_v1_frontend_urls"),
     path("report/backend-urls/", admin_urls_report, name="report_backend_urls"),
     path("report/frontend-urls/", frontend_urls_report, name="report_frontend_urls"),
 ]

--- a/wagtail_unveil/views.py
+++ b/wagtail_unveil/views.py
@@ -79,6 +79,7 @@ def _build_urls_metadata(urls, *, applied_filter):
     """Build metadata describing how a URL payload was produced."""
     testable_count = sum(1 for url in urls if url.is_testable)
     return {
+        "api_version": "v1",
         "generated_at": timezone.now().isoformat(),
         "applied_filter": applied_filter,
         "total_count": len(urls),
@@ -125,7 +126,7 @@ def admin_urls_report(request):
         return HttpResponseNotFound()
 
     context = {
-        "api_url": reverse("wagtail_unveil:api_backend_urls"),
+        "api_url": reverse("wagtail_unveil:api_v1_backend_urls"),
         "report_kind": "backend",
     }
     return render(request, "wagtail_unveil/admin_urls_report.html", context)
@@ -159,7 +160,7 @@ def frontend_urls_report(request):
 
     pages_per_type = get_pages_per_type()
     context = {
-        "api_url": reverse("wagtail_unveil:api_frontend_urls"),
+        "api_url": reverse("wagtail_unveil:api_v1_frontend_urls"),
         "report_kind": "frontend",
         "pages_per_type": pages_per_type,
     }


### PR DESCRIPTION
## Summary
- move the public JSON endpoints to explicit api/v1 routes and rename the exported URL names
- add metadata.api_version to the API response and point the HTML reports at the versioned endpoints
- update docs, AGENTS guidance, tests, and package versioning to reflect the new v1 contract

## Testing
- make lint
- make coverage

Closes #29