### PR TITLE
Run full tox matrix on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
   python-test-smoke:
     needs: python-lint
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -112,7 +112,7 @@ jobs:
 
   python-test-full-matrix:
     needs: python-lint
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- run `python-test-full-matrix` on pushes to `main` in addition to schedule and manual dispatch
- restrict `python-test-smoke` to pull requests so main pushes do not run duplicate smoke + full matrix jobs
- keep existing workflow triggers and matrix definitions unchanged

Closes #34