### PR TITLE
Optimize frontend URL discovery for large page sets

### DIFF
--- a/tests/test_frontend_urls.py
+++ b/tests/test_frontend_urls.py
@@ -1,11 +1,15 @@
-from django.test import TestCase
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
 from wagtail.models import Page
 
 from sandbox.events.models import EventIndexPage
+from sandbox.forms.models import FormPage
 from wagtail_unveil.discovery.frontend import (
     FrontendURL,
     _build_frontend_url,
     _classify_frontend_candidate,
+    _discover_routable_page_candidates,
     _FrontendCandidate,
     get_frontend_urls,
 )
@@ -136,6 +140,69 @@ class TestRoutableSubUrls(TestCase):
             self.assertEqual(url.page_type, self.page_type)
             self.assertEqual(url.page_title, "Events")
             self.assertTrue(url.name)
+
+
+class TestFrontendPageLimitPerformance(TestCase):
+    def setUp(self):
+        root = Page.objects.first()
+        self.home = root.get_children().first()
+
+    def _publish(self, page):
+        self.home.add_child(instance=page)
+        page.save_revision().publish()
+        return page
+
+    @override_settings(WAGTAIL_UNVEIL_PAGES_PER_TYPE=1)
+    def test_limit_one_skips_extra_pages_before_routable_expansion(self):
+        self._publish(EventIndexPage(title="Events A", slug="events-a"))
+        self._publish(EventIndexPage(title="Events B", slug="events-b"))
+
+        with patch(
+            "wagtail_unveil.discovery.frontend._discover_routable_page_candidates",
+            wraps=_discover_routable_page_candidates,
+        ) as discover_routable:
+            urls = get_frontend_urls()
+
+        event_urls = [u for u in urls if u.page_type == "events.EventIndexPage" and u.source == "page"]
+        self.assertEqual(discover_routable.call_count, 1)
+        self.assertEqual(len({u.page_title for u in event_urls}), 1)
+
+    @override_settings(WAGTAIL_UNVEIL_PAGES_PER_TYPE=0)
+    def test_zero_limit_processes_all_pages(self):
+        self._publish(EventIndexPage(title="Events A", slug="events-a"))
+        self._publish(EventIndexPage(title="Events B", slug="events-b"))
+
+        with patch(
+            "wagtail_unveil.discovery.frontend._discover_routable_page_candidates",
+            wraps=_discover_routable_page_candidates,
+        ) as discover_routable:
+            urls = get_frontend_urls()
+
+        event_urls = [u for u in urls if u.page_type == "events.EventIndexPage" and u.source == "page"]
+        self.assertEqual(discover_routable.call_count, 2)
+        self.assertEqual({u.page_title for u in event_urls}, {"Events A", "Events B"})
+
+    @override_settings(WAGTAIL_UNVEIL_PAGES_PER_TYPE=1)
+    def test_selected_pages_keep_form_and_routable_candidates(self):
+        self._publish(
+            FormPage(
+                title="Contact A",
+                slug="contact-a",
+                from_address="noreply@example.com",
+                to_address="team@example.com",
+                subject="Contact form",
+            )
+        )
+        self._publish(EventIndexPage(title="Events A", slug="events-a"))
+
+        urls = get_frontend_urls()
+
+        form_urls = [u for u in urls if u.page_type == "forms.FormPage" and u.page_title == "Contact A"]
+        event_urls = [u for u in urls if u.page_type == "events.EventIndexPage" and u.page_title == "Events A"]
+
+        self.assertEqual({u.name for u in form_urls}, {"", "landing_page"})
+        self.assertIn("past_events", {u.name for u in event_urls})
+        self.assertIn("events_for_year", {u.name for u in event_urls})
 
 
 class TestFrontendDiscoveryPhases(TestCase):

--- a/wagtail_unveil/discovery/frontend.py
+++ b/wagtail_unveil/discovery/frontend.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
@@ -57,11 +56,18 @@ def _discover_page_candidates():
     from wagtail.models import Page
 
     skip_prefixes = get_skip_url_prefixes()
+    limit = get_pages_per_type()
+    included_pages_by_type = {}
     results = []
     pages = Page.objects.live().specific()
     for page in pages:
         if type(page) is Page:
             continue
+
+        page_type = f"{page._meta.app_label}.{type(page).__name__}"
+        if limit and included_pages_by_type.get(page_type, 0) >= limit:
+            continue
+
         try:
             url = page.url
         except Exception:
@@ -72,7 +78,8 @@ def _discover_page_candidates():
         path = parsed.path
         if _should_skip_frontend_url(path, skip_prefixes):
             continue
-        page_type = f"{page._meta.app_label}.{type(page).__name__}"
+
+        included_pages_by_type[page_type] = included_pages_by_type.get(page_type, 0) + 1
         results.append(
             _FrontendCandidate(
                 url=path,
@@ -96,7 +103,7 @@ def _discover_page_candidates():
         if RoutablePageMixin is not None and isinstance(page, RoutablePageMixin):
             results.extend(_discover_routable_page_candidates(page, path, page_type, skip_prefixes))
 
-    return _apply_page_limit(results)
+    return results
 
 
 def _discover_routable_page_candidates(page, page_path, page_type, skip_prefixes=()):
@@ -127,28 +134,6 @@ def _discover_routable_page_candidates(page, page_path, page_type, skip_prefixes
             )
         )
     return results
-
-
-def _apply_page_limit(candidates):
-    """Apply the configured per-page-type limit while keeping page entries together."""
-    limit = get_pages_per_type()
-    if not limit:
-        return candidates
-
-    page_urls = defaultdict(list)
-    for candidate in candidates:
-        key = (candidate.page_type, candidate.page_title)
-        page_urls[key].append(candidate)
-
-    type_pages = defaultdict(list)
-    for (page_type, _title), urls in page_urls.items():
-        type_pages[page_type].append(urls)
-
-    limited = []
-    for pages_in_type in type_pages.values():
-        for page_entries in pages_in_type[:limit]:
-            limited.extend(page_entries)
-    return limited
 
 
 def _discover_resolver_candidates():


### PR DESCRIPTION
## Summary
- apply WAGTAIL_UNVEIL_PAGES_PER_TYPE during page iteration in frontend discovery (early skip once a page type hits its limit)
- remove the post-collection page limiting flow from normal frontend discovery
- preserve included-page behavior for base page URL, form landing candidates, and routable page sub-routes
- add regression tests for:
  - limit=1 early skip behavior
  - limit=0 no-limit behavior
  - preserving form+routable candidates for selected pages

## Verification
- make lint passed
- uv run --env-file .env django-admin test tests.test_frontend_urls passed
- make coverage currently fails due existing frontend asset expectation tests unrelated to this change