### PR TITLE
Prepare 0.1.0a1 release

### DIFF
--- a/.github/release-0.1.0a1.md
+++ b/.github/release-0.1.0a1.md
@@ -1,0 +1,29 @@
+# wagtail-unveil 0.1.0a1
+
+First public alpha release for `wagtail-unveil`.
+
+This release is intended for early adopters and real-world testing rather than mainstream production use. Expect rough edges and some breaking changes before the first stable release.
+
+## Highlights
+
+- discover frontend and Wagtail admin URLs from a single package
+- inspect discovered URLs through authenticated JSON endpoints
+- review backend URLs, frontend URLs, and effective settings through Wagtail admin reports
+- use the dashboard panel to jump straight into the available diagnostics
+
+## Audience
+
+- developers evaluating `wagtail-unveil` on real Wagtail projects
+- teams willing to test early and share feedback on gaps, edge cases, and DX
+
+## Known expectations for this alpha
+
+- behavior and documentation may still change before a stable release
+- package interfaces should be treated as provisional
+- feedback from real projects will shape the next pre-release iterations
+
+## Install
+
+```bash
+pip install wagtail-unveil==0.1.0a1
+```

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ It exposes discovery through:
 Detailed setup docs: [docs/getting-started/installation.md](docs/getting-started/installation.md)
 
 ```bash
-pip install git+https://github.com/nm-packages/wagtail-unveil.git
+pip install wagtail-unveil==0.1.0a1
 ```
 
-> This package is currently in development and is not yet published on PyPI.
-> Once PyPI releases begin, install it with:
+> `0.1.0a1` is the first public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
+> To track unreleased changes from GitHub instead, use:
 
 ```bash
-pip install wagtail-unveil
+pip install git+https://github.com/nm-packages/wagtail-unveil.git
 ```
 
 Add to your `INSTALLED_APPS`:

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -83,7 +83,7 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
     "total_count": 190,
     "testable_count": 150,
     "untestable_count": 40,
-    "package_version": "0.2.0"
+    "package_version": "0.1.0a1"
   }
 }
 ```
@@ -158,7 +158,7 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
     "total_count": 42,
     "testable_count": 31,
     "untestable_count": 11,
-    "package_version": "0.2.0"
+    "package_version": "0.1.0a1"
   }
 }
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,14 +9,14 @@
 ## Install the Package
 
 ```bash
-pip install git+https://github.com/nm-packages/wagtail-unveil.git
+pip install wagtail-unveil==0.1.0a1
 ```
 
-> This package is currently in development and is not yet published on PyPI.
-> Once PyPI releases begin, install it with:
+> `0.1.0a1` is the first public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
+> To try the latest unreleased changes from GitHub instead:
 >
 > ```bash
-> pip install wagtail-unveil
+> pip install git+https://github.com/nm-packages/wagtail-unveil.git
 > ```
 
 ## Add to INSTALLED_APPS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wagtail-unveil"
-version = "0.2.0"
+version = "0.1.0a1"
 description = "Discover and test all URLs in your Wagtail site — frontend and admin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1125,7 +1125,7 @@ wheels = [
 
 [[package]]
 name = "wagtail-unveil"
-version = "0.2.0"
+version = "0.1.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
## Summary
- correct the package version from the mistaken `0.2.0` to the intended first public alpha release `0.1.0a1`
- update installation and API docs to present `0.1.0a1` as the first PyPI alpha and keep the GitHub install path for unreleased changes
- add a draft GitHub release note for the `0.1.0a1` pre-release

## Verification
- `make lint`
- `make coverage`
- `uv build --sdist --wheel --out-dir /tmp/wagtail-unveil-dist-check`
- `uvx twine check /tmp/wagtail-unveil-dist-check/*`