### PR TITLE
Resolve Wagtail admin API detail URLs from callback cls

### DIFF
--- a/docs/contributing/discovery-architecture.md
+++ b/docs/contributing/discovery-architecture.md
@@ -69,7 +69,7 @@ Backend parameter resolution is phase 4 only. `_resolve_parameterized_url()` att
 6. Reverse the URL with `_reverse_with_instance()` using the selected instance.
 7. If no instance can be selected, keep the route visible but untestable.
 
-`_get_model_from_callback()` still checks callback init kwargs first, then `view_class.model`, then cached-property and MRO-based variants of `model`. For treebeard-backed models, `_get_instance_for_model()` excludes the root node (`depth=1`) before selecting the first instance.
+`_get_model_from_callback()` still checks callback init kwargs first, then inspects classes exposed on `callback.view_class` and `callback.cls`, including direct `model` attributes plus cached-property and MRO-based variants of `model`. For treebeard-backed models, `_get_instance_for_model()` excludes the root node (`depth=1`) before selecting the first instance.
 
 Internal resolution returns a `_ParameterizedURLResolution` object with `resolved_route`, `resolved`, `method`, `detail`, and `attempts`. This metadata is internal only. It exists to make the fallback order and failure path easier to debug and test. Public JSON responses still expose only the existing `BackendURL` fields.
 

--- a/tests/test_admin_urls.py
+++ b/tests/test_admin_urls.py
@@ -14,6 +14,7 @@ from wagtail_unveil.discovery.backend import (
     _DiscoveredAdminRoute,
     _finalize_admin_route,
     _get_instance_for_model,
+    _get_model_from_callback,
     _get_model_from_modeladmin_name,
     _get_namespace_specific_instance,
     _normalize_admin_route,
@@ -243,6 +244,22 @@ class TestAdminDiscoveryPhases(TestCase):
         self.assertEqual(result.resolved_route, "")
 
 
+class TestCallbackModelDiscovery(TestCase):
+    def test_get_model_from_callback_supports_callback_cls_mro(self):
+        class BaseView:
+            model = Document
+
+        class DetailView(BaseView):
+            pass
+
+        def callback(request):
+            return None
+
+        callback.cls = DetailView
+
+        self.assertIs(_get_model_from_callback(callback), Document)
+
+
 class TestParameterisedURLResolution(TestCase):
     """Test that parameterised admin URLs are resolved using real model instances."""
 
@@ -324,6 +341,29 @@ class TestParameterisedURLResolution(TestCase):
     def test_user_edit_url_is_testable(self):
         self._assert_namespace_name_testable("wagtailusers_users", "edit")
 
+    def test_admin_api_detail_urls_are_testable_with_resolved_route(self):
+        expected_pks = {
+            "wagtailadmin_api:pages": Site.objects.get(is_default_site=True).root_page.pk,
+            "wagtailadmin_api:documents": self.document.pk,
+            "wagtailadmin_api:images": self.image.pk,
+        }
+
+        for namespace, expected_pk in expected_pks.items():
+            with self.subTest(namespace=namespace):
+                urls = [u for u in self.urls if u.namespace == namespace and u.name == "detail"]
+                self.assertEqual(len(urls), 1)
+                self.assertTrue(urls[0].is_testable, urls[0].route)
+                self.assertEqual(urls[0].skip_reason, "")
+                self.assertTrue(urls[0].resolved_route, urls[0].route)
+                self.assertIn(f"/{expected_pk}/", urls[0].resolved_route)
+
+    def test_admin_api_action_urls_remain_untestable(self):
+        action_urls = [u for u in self.urls if u.namespace == "wagtailadmin_api:pages" and u.name == "action"]
+        self.assertEqual(len(action_urls), 1)
+        self.assertFalse(action_urls[0].is_testable, action_urls[0].route)
+        self.assertEqual(action_urls[0].skip_reason, "URL requires parameters")
+        self.assertEqual(action_urls[0].resolved_route, "")
+
     def test_resolved_route_has_no_angle_brackets(self):
         resolved = [u for u in self.urls if u.resolved_route]
         self.assertGreater(len(resolved), 0)
@@ -345,6 +385,19 @@ class TestParameterisedURLResolution(TestCase):
         for url in unresolvable:
             self.assertFalse(url.is_testable, url.route)
             self.assertIn(url.skip_reason, ("URL requires parameters", "POST-only view"))
+
+    @mock.patch("wagtail_unveil.discovery.backend._get_instance_for_model", return_value=None)
+    def test_admin_api_detail_urls_stay_untestable_without_instances(self, get_instance):
+        urls = get_admin_urls()
+        detail_urls = [u for u in urls if u.namespace.startswith("wagtailadmin_api:") and u.name == "detail"]
+
+        self.assertGreater(len(detail_urls), 0)
+        for url in detail_urls:
+            self.assertFalse(url.is_testable, url.route)
+            self.assertEqual(url.skip_reason, "URL requires parameters")
+            self.assertEqual(url.resolved_route, "")
+
+        self.assertGreaterEqual(get_instance.call_count, 3)
 
 
 class TestParameterizedResolutionStrategies(TestCase):

--- a/wagtail_unveil/discovery/backend.py
+++ b/wagtail_unveil/discovery/backend.py
@@ -132,25 +132,24 @@ def _get_model_from_modeladmin_name(name):
         return None
 
 
-def _get_model_from_callback(callback):
-    """Extract a Django model class from a view callback.
+def _get_model_from_view_class(view_class):
+    """Extract a Django model class from a view class or its MRO."""
+    if not view_class:
+        return None
 
-    Checks three sources in order:
-    1. view_initkwargs["model"] — ModelViewSet views (as_view(model=Model))
-    2. view_class.__dict__["model"] as a plain class attribute
-    3. view_class.__dict__["model"] as a cached_property (calls func(None))
-    """
-    # Source 1: initkwargs (ModelViewSet pattern)
-    initkwargs = getattr(callback, "initkwargs", None) or getattr(callback, "view_initkwargs", None)
-    if initkwargs:
-        model = initkwargs.get("model")
-        if _is_django_model(model):
-            return model
+    model_attr = view_class.__dict__.get("model")
+    if _is_django_model(model_attr):
+        return model_attr
+    if isinstance(model_attr, (cached_property, django_cached_property)):
+        try:
+            model = model_attr.func(None)
+            if _is_django_model(model):
+                return model
+        except Exception:
+            pass
 
-    # Sources 2 & 3: class attribute or cached_property on view_class
-    view_class = getattr(callback, "view_class", None)
-    if view_class:
-        model_attr = view_class.__dict__.get("model")
+    for cls in view_class.__mro__:
+        model_attr = cls.__dict__.get("model")
         if _is_django_model(model_attr):
             return model_attr
         if isinstance(model_attr, (cached_property, django_cached_property)):
@@ -161,18 +160,28 @@ def _get_model_from_callback(callback):
             except Exception:
                 pass
 
-        # Source 4: model inherited from a parent class (e.g. search promotions mixin)
-        for cls in view_class.__mro__:
-            model_attr = cls.__dict__.get("model")
-            if _is_django_model(model_attr):
-                return model_attr
-            if isinstance(model_attr, (cached_property, django_cached_property)):
-                try:
-                    model = model_attr.func(None)
-                    if _is_django_model(model):
-                        return model
-                except Exception:
-                    pass
+    return None
+
+
+def _get_model_from_callback(callback):
+    """Extract a Django model class from a view callback.
+
+    Checks callback metadata in order:
+    1. view_initkwargs["model"] — ModelViewSet views (as_view(model=Model))
+    2. callback.view_class and its MRO
+    3. callback.cls and its MRO
+    """
+    # Source 1: initkwargs (ModelViewSet pattern)
+    initkwargs = getattr(callback, "initkwargs", None) or getattr(callback, "view_initkwargs", None)
+    if initkwargs:
+        model = initkwargs.get("model")
+        if _is_django_model(model):
+            return model
+
+    for view_class in (getattr(callback, "view_class", None), getattr(callback, "cls", None)):
+        model = _get_model_from_view_class(view_class)
+        if model is not None:
+            return model
 
     return None
 


### PR DESCRIPTION
Closes #57

## Summary
- teach backend callback model discovery to inspect classes exposed on `callback.cls` as well as `view_class`
- allow Wagtail admin API detail routes for pages, documents, and images to resolve to concrete PK-backed URLs when matching objects exist
- add regression coverage for `callback.cls` model lookup, admin API detail resolution, multi-parameter action routes remaining untestable, and the no-instance fallback
- update the discovery architecture notes to document `callback.cls` model inference

## Validation
- `uv run --env-file .env django-admin test tests.test_admin_urls`
- `make lint`
- `make coverage`