### PR TITLE
Update package version to 0.1.0a2

### DIFF
--- a/.github/release-0.1.0a2.md
+++ b/.github/release-0.1.0a2.md
@@ -1,0 +1,30 @@
+# wagtail-unveil 0.1.0a2
+
+Second public alpha release for `wagtail-unveil`.
+
+This release is still intended for early adopters and real-world testing rather than mainstream production use. Expect ongoing refinement and some breaking changes before the first stable release.
+
+## Highlights
+
+- improve frontend URL discovery for `RoutablePageMixin` sub-routes, including better concrete URL resolution
+- surface query-driven Wagtail API `find/` routes in frontend discovery with clearer non-testable handling
+- make Wagtail admin API detail URLs testable when a representative object can be resolved
+- keep POST-only reorder routes visible in backend discovery while marking them untestable
+- refresh docs and release metadata for the current alpha
+
+## Audience
+
+- developers evaluating `wagtail-unveil` on real Wagtail projects
+- teams willing to test early and share feedback on gaps, edge cases, and DX
+
+## Known expectations for this alpha
+
+- behavior and documentation may still change before a stable release
+- package interfaces should be treated as provisional
+- feedback from real projects will shape the next pre-release iterations
+
+## Install
+
+```bash
+pip install wagtail-unveil==0.1.0a2
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to `wagtail-unveil` are documented in this file.
+
+## 0.1.0a2 - 2026-03-22
+
+Second public alpha release.
+
+This alpha continues to target early adopters and real-world testing. Package behavior and documentation should still be treated as provisional before the first stable release.
+
+### Highlights
+
+- improved frontend URL discovery for `RoutablePageMixin` sub-routes, including better concrete URL resolution and clearer handling for regex-backed routes
+- surfaced query-driven Wagtail API `find/` routes in frontend discovery without treating them as directly testable GET URLs
+- made Wagtail admin API detail URLs testable when a representative object can be resolved
+- marked POST-only reorder routes as visible but untestable in backend discovery
+- refreshed documentation and package presentation for the current alpha release
+
+## 0.1.0a1 - 2026-03-02
+
+First public alpha release.
+
+This alpha introduced the initial public package surface for early adopters and feedback.
+
+### Highlights
+
+- discovered frontend and Wagtail admin URLs from a single reusable package
+- exposed authenticated JSON API endpoints for inspecting discovered URLs
+- added Wagtail admin reports for backend URLs, frontend URLs, and effective settings
+- included a dashboard panel for quick access to the available diagnostics

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ It exposes discovery through:
 Detailed setup docs: [docs/getting-started/installation.md](docs/getting-started/installation.md)
 
 ```bash
-pip install wagtail-unveil==0.1.0a1
+pip install wagtail-unveil==0.1.0a2
 ```
 
-> `0.1.0a1` is the first public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
+> `0.1.0a2` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
 > To track unreleased changes from GitHub instead, use:
 
 ```bash
@@ -101,6 +101,7 @@ For full setting details, including environment variable usage, normalization ru
 - API versioning policy: [docs/contributing/api-versioning.md](docs/contributing/api-versioning.md)
 - Discovery internals: [docs/contributing/discovery-architecture.md](docs/contributing/discovery-architecture.md)
 - Frontend asset workflow: [docs/contributing/frontend-assets.md](docs/contributing/frontend-assets.md)
+- Changelog: [CHANGELOG.md](CHANGELOG.md)
 - Release runbook: [docs/contributing/releasing.md](docs/contributing/releasing.md)
 - Agent-facing project guidance: [AGENTS.md](AGENTS.md)
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -83,7 +83,7 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
     "total_count": 190,
     "testable_count": 150,
     "untestable_count": 40,
-    "package_version": "0.1.0a1"
+    "package_version": "0.1.0a2"
   }
 }
 ```
@@ -160,7 +160,7 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
     "total_count": 42,
     "testable_count": 31,
     "untestable_count": 11,
-    "package_version": "0.1.0a1"
+    "package_version": "0.1.0a2"
   }
 }
 ```

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -30,11 +30,13 @@ The GitHub repository and workflow identity must match exactly, or publish will 
 ## Maintainer Release Steps
 
 1. Update `version` in `pyproject.toml` to the intended release version.
-2. Merge the version bump to `main`.
-3. Ensure normal CI on `main` is green (`CI` workflow).
-4. Create a GitHub Release with a tag that matches the package version with `v` prefix.
-5. Publish the GitHub Release.
-6. Confirm `.github/workflows/release.yml` succeeds and the version appears on PyPI.
+2. Update `CHANGELOG.md` with a concise entry for the new release and any migration or alpha-status notes worth calling out.
+3. Merge the release-prep changes to `main`.
+4. Ensure normal CI on `main` is green (`CI` workflow).
+5. Create a GitHub Release with a tag that matches the package version with `v` prefix.
+6. Use the matching `.github/release-*.md` file or the `CHANGELOG.md` entry as the GitHub Release body.
+7. Publish the GitHub Release.
+8. Confirm `.github/workflows/release.yml` succeeds and the version appears on PyPI.
 
 For local sandbox/test command workflows before a release, use:
 - [`development.md`](development.md) for canonical developer workflow and quickstart commands

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,10 +9,10 @@
 ## Install the Package
 
 ```bash
-pip install wagtail-unveil==0.1.0a1
+pip install wagtail-unveil==0.1.0a2
 ```
 
-> `0.1.0a1` is the first public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
+> `0.1.0a2` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
 > To try the latest unreleased changes from GitHub instead:
 >
 > ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wagtail-unveil"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "Discover and test all URLs in your Wagtail site — frontend and admin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1125,7 +1125,7 @@ wheels = [
 
 [[package]]
 name = "wagtail-unveil"
-version = "0.1.0a1"
+version = "0.1.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
## Summary
- bump `project.version` in `pyproject.toml` from `0.1.0a1` to `0.1.0a2`
- prepare the package metadata for the next pre-release

## Testing
- Not run (not requested)