### PR TITLE
Prepare v0.1.0a3 release

### DIFF
--- a/.github/release-0.1.0a3.md
+++ b/.github/release-0.1.0a3.md
@@ -1,0 +1,29 @@
+# wagtail-unveil 0.1.0a3
+
+Third public alpha release for `wagtail-unveil`.
+
+This release is still intended for early adopters and real-world testing rather than mainstream production use. Expect ongoing refinement and some breaking changes before the first stable release.
+
+## Highlights
+
+- add hook-based admin instance resolver extensions for developer-installed Wagtail admin packages
+- document the custom resolver pattern with a `wagtail-modeladmin` recipe and sandbox example
+- split admin and frontend parameter resolution into dedicated modules with broader automated coverage
+- harden third-party resolver extension failures so bad hook output is skipped without taking discovery down
+
+## Audience
+
+- developers evaluating `wagtail-unveil` on real Wagtail projects
+- teams willing to test early and share feedback on gaps, edge cases, and DX
+
+## Known expectations for this alpha
+
+- behavior and documentation may still change before a stable release
+- package interfaces should be treated as provisional
+- feedback from real projects will shape the next pre-release iterations
+
+## Install
+
+```bash
+pip install wagtail-unveil==0.1.0a3
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `wagtail-unveil` are documented in this file.
 
+## 0.1.0a3 - 2026-03-23
+
+Third public alpha release.
+
+This alpha continues to target early adopters and real-world testing. Package behavior and documentation should still be treated as provisional before the first stable release.
+
+### Highlights
+
+- added hook-based admin instance resolver extensions so projects can support developer-installed Wagtail admin packages without patching core discovery
+- documented the custom admin resolver hook pattern, including a `wagtail-modeladmin` recipe and sandbox example integration
+- refactored admin and frontend parameter resolution into dedicated modules with broader test coverage
+- hardened third-party resolver extension handling so invalid hook output degrades gracefully with warnings instead of breaking discovery
+
 ## 0.1.0a2 - 2026-03-22
 
 Second public alpha release.

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ It exposes discovery through:
 Detailed setup docs: [docs/getting-started/installation.md](docs/getting-started/installation.md)
 
 ```bash
-pip install wagtail-unveil==0.1.0a2
+pip install wagtail-unveil==0.1.0a3
 ```
 
-> `0.1.0a2` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
+> `0.1.0a3` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
 > To track unreleased changes from GitHub instead, use:
 
 ```bash

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -83,7 +83,7 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
     "total_count": 190,
     "testable_count": 150,
     "untestable_count": 40,
-    "package_version": "0.1.0a2"
+    "package_version": "0.1.0a3"
   }
 }
 ```
@@ -160,7 +160,7 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
     "total_count": 42,
     "testable_count": 31,
     "untestable_count": 11,
-    "package_version": "0.1.0a2"
+    "package_version": "0.1.0a3"
   }
 }
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,10 +9,10 @@
 ## Install the Package
 
 ```bash
-pip install wagtail-unveil==0.1.0a2
+pip install wagtail-unveil==0.1.0a3
 ```
 
-> `0.1.0a2` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
+> `0.1.0a3` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
 > To try the latest unreleased changes from GitHub instead:
 >
 > ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wagtail-unveil"
-version = "0.1.0a2"
+version = "0.1.0a3"
 description = "Discover and test all URLs in your Wagtail site — frontend and admin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1125,7 +1125,7 @@ wheels = [
 
 [[package]]
 name = "wagtail-unveil"
-version = "0.1.0a2"
+version = "0.1.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
## Summary
- bump the package version to `0.1.0a3`
- add release notes and changelog entries for the third public alpha release
- update install and API documentation examples to reference `0.1.0a3`

## Testing
- `make lint`
- `make coverage`
- `uv build --sdist --wheel --out-dir /tmp/wagtail-unveil-dist-check-0.1.0a3`
- `uvx twine check /tmp/wagtail-unveil-dist-check-0.1.0a3/*`