### PR TITLE
Prepare 0.1.0a5 release

### DIFF
--- a/.github/release-0.1.0a5.md
+++ b/.github/release-0.1.0a5.md
@@ -1,0 +1,48 @@
+# wagtail-unveil 0.1.0a5
+
+Fifth public alpha release for `wagtail-unveil`.
+
+This release is still intended for early adopters and real-world testing rather than mainstream production use. Expect ongoing refinement and some breaking changes before the first stable release.
+
+## Full Change Summary
+
+- surface concrete backend page-admin routes per discovered page type so more page-specific admin URLs are visible and testable
+- cache page-type admin expansion work per discovery run to avoid repeating the same compatibility checks
+- normalize frontend skip prefixes for django-admin routes so exclusions apply more consistently during discovery
+- remove redundant `wagtailadmin_pages` hook resolvers after the page-type route expansion work
+- add discovery workflow reference documentation to explain the backend and frontend pipelines more clearly
+- clarify the discovery docs and tidy supporting report helpers
+
+## Audience
+
+- developers evaluating `wagtail-unveil` on real Wagtail projects
+- teams willing to test early and share feedback on gaps, edge cases, and DX
+
+## Known expectations for this alpha
+
+- behavior and documentation may still change before a stable release
+- package interfaces should be treated as provisional
+- feedback from real projects will shape the next pre-release iterations
+
+## Since 0.1.0a4
+
+### Admin Discovery
+
+- backend discovery now emits compatible page-admin routes for each concrete page type present in the database instead of only listing generic patterns
+- repeated page-type expansion work is cached inside a discovery run, which keeps the broader route surface practical to compute
+- redundant hook-based page resolver logic was removed now that page-type expansion covers the supported cases directly
+
+### Frontend Discovery
+
+- skip-prefix handling is stricter about normalizing django-admin-style prefixes before matching, which makes exclusions more predictable
+
+### Documentation And Maintenance
+
+- new workflow diagrams document the backend and frontend discovery pipeline for contributors
+- supporting docs and helper cleanup keep the codebase aligned with the project’s flow-first conventions
+
+## Install
+
+```bash
+pip install wagtail-unveil==0.1.0a5
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `wagtail-unveil` are documented in this file.
 
+## 0.1.0a5 - 2026-04-02
+
+Fifth public alpha release.
+
+This alpha continues to target early adopters and real-world testing. Package behavior and documentation should still be treated as provisional before the first stable release.
+
+### Highlights
+
+- surfaced concrete backend page-admin routes per discovered page type so page-specific admin views are easier to inspect and test
+- cached page-type admin expansion work per discovery run while tightening frontend skip-prefix normalization for django-admin routes
+- added discovery workflow reference diagrams and related contributor docs to make the discovery pipeline easier to understand and extend
+
 ## 0.1.0a4 - 2026-03-25
 
 Fourth public alpha release.

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ It exposes discovery through:
 Detailed setup docs: [docs/getting-started/installation.md](https://github.com/nm-packages/wagtail-unveil/blob/main/docs/getting-started/installation.md)
 
 ```bash
-pip install wagtail-unveil==0.1.0a4
+pip install wagtail-unveil==0.1.0a5
 ```
 
-> `0.1.0a4` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
+> `0.1.0a5` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
 > To track unreleased changes from GitHub instead, use:
 
 ```bash

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -84,7 +84,7 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
     "total_count": 190,
     "testable_count": 150,
     "untestable_count": 40,
-    "package_version": "0.1.0a4"
+    "package_version": "0.1.0a5"
   }
 }
 ```
@@ -162,7 +162,7 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
     "total_count": 42,
     "testable_count": 31,
     "untestable_count": 11,
-    "package_version": "0.1.0a4"
+    "package_version": "0.1.0a5"
   }
 }
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,10 +9,10 @@
 ## Install the Package
 
 ```bash
-pip install wagtail-unveil==0.1.0a4
+pip install wagtail-unveil==0.1.0a5
 ```
 
-> `0.1.0a4` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
+> `0.1.0a5` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
 > To try the latest unreleased changes from GitHub instead:
 >
 > ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wagtail-unveil"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "Discover and test all URLs in your Wagtail site — frontend and admin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1125,7 +1125,7 @@ wheels = [
 
 [[package]]
 name = "wagtail-unveil"
-version = "0.1.0a4"
+version = "0.1.0a5"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
# wagtail-unveil 0.1.0a5

Fifth public alpha release for `wagtail-unveil`.

This release is still intended for early adopters and real-world testing rather than mainstream production use. Expect ongoing refinement and some breaking changes before the first stable release.

## Full Change Summary

- surface concrete backend page-admin routes per discovered page type so more page-specific admin URLs are visible and testable
- cache page-type admin expansion work per discovery run to avoid repeating the same compatibility checks
- normalize frontend skip prefixes for django-admin routes so exclusions apply more consistently during discovery
- remove redundant `wagtailadmin_pages` hook resolvers after the page-type route expansion work
- add discovery workflow reference documentation to explain the backend and frontend pipelines more clearly
- clarify the discovery docs and tidy supporting report helpers

## Audience

- developers evaluating `wagtail-unveil` on real Wagtail projects
- teams willing to test early and share feedback on gaps, edge cases, and DX

## Known expectations for this alpha

- behavior and documentation may still change before a stable release
- package interfaces should be treated as provisional
- feedback from real projects will shape the next pre-release iterations

## Since 0.1.0a4

### Admin Discovery

- backend discovery now emits compatible page-admin routes for each concrete page type present in the database instead of only listing generic patterns
- repeated page-type expansion work is cached inside a discovery run, which keeps the broader route surface practical to compute
- redundant hook-based page resolver logic was removed now that page-type expansion covers the supported cases directly

### Frontend Discovery

- skip-prefix handling is stricter about normalizing django-admin-style prefixes before matching, which makes exclusions more predictable

### Documentation And Maintenance

- new workflow diagrams document the backend and frontend discovery pipeline for contributors
- supporting docs and helper cleanup keep the codebase aligned with the project’s flow-first conventions

## Install

```bash
pip install wagtail-unveil==0.1.0a5
```
