### PR TITLE
Slim AGENTS.md and re-center repo conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ This file is the canonical guidance for coding agents working in this repository
 
 - `README.md` — user-facing package overview and minimal quickstart
 - `docs/index.md` — canonical documentation hub for users, contributors, and maintainers
-- `docs/contributing/development.md` — human contributor setup, day-to-day workflow, and CI-aligned dev commands
+- `docs/contributing/development.md` — canonical contributor command, validation, and CI-aligned workflow guide
+- `CONVENTIONS.md` — canonical coding, testing, and documentation conventions
 - `AGENTS.md` files — canonical agent-facing guidance and documentation contract
 
 ## Issue Startup Workflow
@@ -47,94 +48,7 @@ Required PR-metadata check when working on an existing branch:
 
 Safety rule: do not start implementation for issue-scoped work on `main` when the issue is expected to have its own branch. Do not start newly scoped work on `main` without first checking whether the user wants a branch created and proposing a suitable branch title. When working on a branch with an open PR, do not ignore title/summary drift if the branch scope has materially changed.
 
-## Development Commands
-
-These commands are for contributors working in this repository's sandbox and test environment. They are not package-level interfaces exposed by `wagtail_unveil`.
-
-Prefer the `Makefile` targets for standard workflows:
-
-Setup:
-
-```bash
-make setup           # env, install, migrate, sample data
-make env             # copy .env.example to .env if needed
-make install         # install Python dependencies with uv
-make migrate         # run Django migrations
-make superuser       # create a superuser
-make sample-data     # create sample data
-```
-
-Development:
-
-```bash
-make runserver       # start the sandbox dev server
-make run             # alias for runserver
-make makemigrations  # create package migrations
-```
-
-Validation:
-
-```bash
-make test            # run package tests
-make test-js         # run JavaScript report tests
-make lint            # ruff check
-make lint-fix        # ruff check --fix
-make lint-assets     # Biome frontend asset lint/format checks (JavaScript + CSS)
-make lint-assets-fix # Biome frontend asset lint/format with autofix
-make coverage        # run tests with coverage report
-make coverage-html   # generate HTML coverage report
-make pre-commit      # run all configured hooks
-```
-
-Docs:
-
-```bash
-make docs-build      # build the HTML documentation site
-make docs-serve      # run the HTML documentation site locally
-```
-
-Matrix / release checks:
-
-```bash
-make tox             # run the version matrix
-make tox-smoke       # run the fast smoke subset used in PR CI
-make build-assets    # build report frontend assets (JavaScript + CSS)
-```
-
-Cleanup:
-
-```bash
-make clean           # remove db.sqlite3, .env, and media
-```
-
-Equivalent direct commands are also valid for the main workflows:
-
-```bash
-uv sync
-uv run --env-file .env django-admin migrate
-uv run --env-file .env django-admin runserver
-uv run --env-file .env django-admin test tests
-uv run ruff check .
-uv run --group docs mkdocs build --strict
-uv run --group docs mkdocs serve
-uv run tox
-uv run tox -m smoke
-npm run lint:assets
-npm run lint:assets:fix
-npm run test:js
-npm run build:assets
-```
-
-Release preflight commands:
-
-```bash
-uv build --sdist --wheel --out-dir /tmp/wagtail-unveil-dist-check
-uvx twine check /tmp/wagtail-unveil-dist-check/*
-```
-
-Maintainer release publishing is CI-driven from GitHub Releases via `.github/workflows/release.yml`.
-Use `docs/contributing/releasing.md` as the canonical release runbook.
-Use `mkdocs.yml` as the canonical HTML docs site configuration.
+For contributor commands, validation loops, and release-adjacent workflow, use `docs/contributing/development.md` as the canonical reference. For coding, testing, and documentation conventions, use `CONVENTIONS.md`.
 
 ## Architecture Summary
 
@@ -150,14 +64,7 @@ The core discovery logic lives in `wagtail_unveil/discovery/`.
 - `discovery/utils.py` — shared resolver walking and route normalization helpers
 - `docs/contributing/discovery-architecture.md` — canonical contributor-facing explanation of discovery, normalization, parameter resolution, and testability rules
 
-Admin URL discovery walks Django's resolver tree, filters to admin routes, and attempts to resolve parameterized URLs against real database objects where possible.
-Developer-installed Wagtail packages can extend that parameter resolution through the `register_unveil_admin_instance_resolvers` Wagtail hook instead of adding package-specific logic directly to `wagtail_unveil`.
-
-Frontend URL discovery combines:
-
-- live Wagtail page URLs
-- additional page-derived URLs such as form landing pages and `RoutablePageMixin` sub-routes
-- non-admin Django resolver routes
+Admin discovery walks the Django resolver tree, filters to admin routes, and resolves supported parameterized URLs against real objects where possible. Frontend discovery combines live page URLs, page-derived URLs, and non-admin resolver routes. Use `docs/contributing/discovery-architecture.md` for the full discovery rules instead of duplicating them here.
 
 ### Delivery Layer
 
@@ -177,40 +84,13 @@ Routes provided:
 - `report/frontend-urls/` → `wagtail_unveil:report_frontend_urls`
 - `report/settings/` → `wagtail_unveil:report_settings`
 
-Versioned API paths, URL names, and lifecycle metadata are derived from the
-internal `wagtail_unveil.api_contract.API_VERSION_REGISTRY`.
-New API versions should be added in parallel and deprecate older versions over a documented window.
-Additional `api/vN/...` routes may be present when newer versions are introduced.
-Canonical contributor policy for versioning decisions and implementation workflow:
-`docs/contributing/api-versioning.md`.
+Versioned API paths, URL names, and lifecycle metadata are derived from `wagtail_unveil.api_contract.API_VERSION_REGISTRY`. Use `docs/contributing/api-versioning.md` for versioning policy and workflow.
 
 JSON endpoints use Bearer token auth via `WAGTAIL_UNVEIL_API_KEY`. HTML report views require a superuser and `DEBUG=True`.
 
 ### Sandbox
 
 The sandbox project mounts the package at `/unveil/`, exposes Wagtail API v2 routes at `/api/v2/`, and serves Wagtail pages from `/`.
-
-## Coding Conventions
-
-See [CONVENTIONS.md](https://github.com/nm-packages/wagtail-unveil/blob/main/CONVENTIONS.md) for the full project conventions. Important rules:
-
-- Use double quotes consistently
-- Sort modules using the flow-first organization guidance in `CONVENTIONS.md`
-- Use `path()` and namespaced URLs
-- Keep `wagtail_unveil/` independent from `sandbox/`
-- Prefer Wagtail ViewSet patterns for admin integration
-- Keep tests in the root `tests/` package
-
-## Verification Expectations
-
-After changing code in `wagtail_unveil/` or `tests/`:
-
-1. Run `make lint`
-2. Run `make coverage`
-3. Inspect coverage for touched files and add tests for newly introduced uncovered lines
-4. Update `README.md` and relevant agent guidance files when behavior or structure changes
-
-For notable merged-but-unreleased work, update `CHANGELOG.md` under `## Unreleased` in the same PR. During release prep, convert those notes into the new versioned release entry and leave a fresh `## Unreleased` section in place.
 
 ## Directory-Specific Guidance
 
@@ -222,11 +102,12 @@ More focused guidance lives in:
 ## Documentation Contract
 
 - `AGENTS.md` files are the canonical agent-facing project guidance
-- Root `AGENTS.md` owns repo-wide guidance
-- Nested `AGENTS.md` files own only directory-local guidance
+- Root `AGENTS.md` owns repo-wide agent workflow, repo orientation, and doc routing
+- Nested `AGENTS.md` files own only directory-local agent guidance
+- `CONVENTIONS.md` is the canonical reference for coding, testing, and documentation conventions
+- `docs/contributing/development.md` is the canonical contributor workflow guide for commands, validation loops, and CI-oriented development
 - `docs/contributing/discovery-architecture.md` is the canonical contributor-facing reference for discovery and resolution behavior; AGENTS files should point to it rather than duplicating detailed flow logic
-- `docs/contributing/development.md` is the canonical human contributor workflow guide for local setup, validation loops, and CI-oriented dev commands
 - `docs/contributing/frontend-assets.md` is the canonical contributor-facing reference for frontend asset source, build/test workflow, and CI expectations
 - `docs/contributing/api-versioning.md` is the canonical contributor-facing reference for API version lifecycle policy and version-bump workflow
 - `docs/contributing/releasing.md` is the canonical contributor-facing reference for release workflow, PyPI Trusted Publisher setup, and maintainer release troubleshooting
-- Command-level docs must stay in sync with `Makefile`; when targets change, update `AGENTS.md` and `docs/contributing/development.md` in the same PR. `README.md` should link to this contributor workflow, not duplicate command lists.
+- `README.md` should stay focused on package overview and quickstart, linking out to canonical contributor docs instead of duplicating workflow detail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes merged to `main` since the last release.
 - added an MkDocs + Material HTML docs site with Mermaid rendering, CI validation, and GitHub Pages deployment
 - grouped `make help` commands by workflow and aligned contributor command guidance across the development docs and AGENTS guidance
 - clarified agent workflow for issue-linked branches, new scoped work started from `main`, and open-PR title/summary drift checks
+- slimmed `AGENTS.md` and moved coding, testing, documentation, and command-workflow ownership more clearly into `CONVENTIONS.md` and contributor docs
 
 ## 0.1.0a5 - 2026-04-02
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -33,7 +33,10 @@
 ## Documentation
 
 - **Pre-commit hooks** are configured in `.pre-commit-config.yaml` — run `make pre-commit` to check all files, or `uv run pre-commit install` to enable automatic checks on each commit
-- **After each piece of work**, run lint and coverage checks (see the workflow in root AGENTS.md), then update the relevant AGENTS.md files and README.md to reflect new features, files, or changes
-- **Docs sync checklist:** if `Makefile` targets or command behavior changes, update command docs in `AGENTS.md` and `docs/contributing/development.md` in the same PR
+- **Canonical workflow docs:** use `docs/contributing/development.md` for contributor commands, validation loops, and CI-aligned day-to-day workflow; use `AGENTS.md` for agent-only repo workflow and context
+- **After code changes in `wagtail_unveil/` or `tests/`**, run `make lint` and `make coverage`, then inspect coverage for touched files and add tests for newly introduced uncovered lines
+- **Changelog:** for notable unreleased user-visible, contributor-visible, or maintainer-relevant work, add a concise note under `CHANGELOG.md` -> `## Unreleased` in the same PR
+- **Docs maintenance:** update `README.md`, relevant `AGENTS.md` files, and canonical contributor docs when behavior, structure, or doc ownership changes
+- **Docs sync checklist:** if `Makefile` targets or command behavior changes, update command docs in `docs/contributing/development.md` in the same PR; keep `AGENTS.md` doc-routing references accurate if the canonical sources change
 - **README.md** is user-facing documentation — document features, usage, and configuration
-- **AGENTS.md files** are the canonical agent context files — document key files, structure, and conventions
+- **AGENTS.md files** are the canonical agent context files — document repo orientation, key files, and agent workflow rather than full contributor command catalogs

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -90,9 +90,11 @@ See `.github/workflows/ci.yml` for exact job definitions. The HTML docs site is 
 When changing contributor commands or Make targets:
 
 1. Update `Makefile`.
-2. Update command docs in `AGENTS.md` and this file.
+2. Update command docs in this file.
 3. Keep `README.md` focused and linked to this file.
 4. Keep those command-doc updates in the same PR as the Makefile/command change.
+
+`AGENTS.md` should continue to point agents at this guide for command and validation workflow, but it should not duplicate the full command catalog.
 
 When making notable user-visible, contributor-visible, or maintainer-relevant changes that are not yet released:
 
@@ -103,7 +105,7 @@ When making notable user-visible, contributor-visible, or maintainer-relevant ch
 
 - User-facing package overview: [README.md](https://github.com/nm-packages/wagtail-unveil/blob/main/README.md)
 - Coding conventions: [CONVENTIONS.md](https://github.com/nm-packages/wagtail-unveil/blob/main/CONVENTIONS.md)
-- Agent project guidance: [AGENTS.md](https://github.com/nm-packages/wagtail-unveil/blob/main/AGENTS.md)
+- Agent project guidance: [AGENTS.md](https://github.com/nm-packages/wagtail-unveil/blob/main/AGENTS.md) — agent-facing repo context and startup workflow; use this page as the canonical command and validation reference.
 - Documentation hub: [../index.md](../index.md)
 - Frontend assets: [frontend-assets.md](frontend-assets.md)
 - API lifecycle/versioning: [api-versioning.md](api-versioning.md)


### PR DESCRIPTION
## Summary
- slim `AGENTS.md` so it stays focused on agent-only repo context and workflow
- keep the issue/branch/PR startup guidance in `AGENTS.md`
- move coding, testing, documentation, and validation ownership more clearly into `CONVENTIONS.md` and `docs/contributing/development.md`
- remove duplicated command/catalog material from `AGENTS.md` and replace it with pointers to the canonical docs
- add an unreleased changelog note for the documentation ownership cleanup

## Testing
- reviewed the updated docs split across `AGENTS.md`, `CONVENTIONS.md`, and `docs/contributing/development.md`
- ran `make docs-build`

## Notes
- documentation-only change; no package, sandbox, or test behavior changes