### PR TITLE
Remove redundant overlapping test coverage

### DIFF
--- a/tests/discovery/admin/test_resolution_integration.py
+++ b/tests/discovery/admin/test_resolution_integration.py
@@ -181,18 +181,6 @@ class TestParameterisedURLResolution(TestCase):
         self.assertEqual(action_urls[0].skip_reason, "URL requires parameters")
         self.assertEqual(action_urls[0].resolved_route, "")
 
-    def test_resolved_route_has_no_angle_brackets(self):
-        resolved = [u for u in self.urls if u.resolved_route]
-        self.assertGreater(len(resolved), 0)
-        for url in resolved:
-            self.assertNotIn("<", url.resolved_route, url.route)
-
-    def test_multi_param_urls_remain_untestable(self):
-        multi_param = [u for u in self.urls if u.has_parameters and u.route.count("<") > 1 and not u.resolved_route]
-        for url in multi_param:
-            self.assertFalse(url.is_testable, url.route)
-            self.assertEqual(url.skip_reason, "URL requires parameters")
-
     def test_searchpick_edit_url_is_testable(self):
         self._assert_namespace_name_testable("searchpromotions", "edit")
 
@@ -277,13 +265,6 @@ class TestParameterisedURLResolution(TestCase):
             self.assertEqual(url.skip_reason, "POST-only view")
             self.assertTrue(url.resolved_route, url.route)
             self.assertRegex(url.resolved_route, r"admin/.+/reorder/\d+/")
-
-    def test_unresolvable_parameterised_urls_are_untestable(self):
-        unresolvable = [u for u in self.urls if u.has_parameters and not u.resolved_route]
-        self.assertGreater(len(unresolvable), 0)
-        for url in unresolvable:
-            self.assertFalse(url.is_testable, url.route)
-            self.assertIn(url.skip_reason, ("URL requires parameters", "POST-only view"))
 
     @mock.patch("wagtail_unveil.discovery.backend_resolution._get_instance_for_model", return_value=None)
     def test_admin_api_detail_urls_stay_untestable_without_instances(self, get_instance):

--- a/tests/discovery/frontend/test_multisite.py
+++ b/tests/discovery/frontend/test_multisite.py
@@ -32,15 +32,11 @@ class TestMultisiteFrontendUrls(TestCase):
 
         self.urls = get_frontend_urls()
 
-    def test_non_default_site_page_is_discovered(self):
-        matches = [u for u in self.urls if u.source == "page" and u.page_title == "Subsite About"]
-        self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].url, "/subsite-about/")
-
-    def test_non_default_site_page_is_marked_untestable(self):
+    def test_non_default_site_page_is_discovered_but_marked_untestable(self):
         matches = [u for u in self.urls if u.source == "page" and u.page_title == "Subsite About"]
         self.assertEqual(len(matches), 1)
         match = matches[0]
+        self.assertEqual(match.url, "/subsite-about/")
         self.assertFalse(match.is_testable)
         self.assertEqual(match.skip_reason, "Belongs to non-default site host: sub.localhost:8000")
 

--- a/tests/sandbox/test_urls.py
+++ b/tests/sandbox/test_urls.py
@@ -27,16 +27,3 @@ class TestSandboxWagtailAPI(TestCase):
 
         self.assertEqual(match.url_name, "find")
         self.assertEqual(match.namespace, "wagtailapi:pages")
-
-    def test_api_v2_find_routes_are_discovered(self):
-        urls = [url for url in get_frontend_urls() if url.name == "find" and url.url.startswith("/api/v2/")]
-
-        self.assertEqual(
-            {url.url for url in urls},
-            {
-                "/api/v2/pages/find/",
-                "/api/v2/images/find/",
-                "/api/v2/documents/find/",
-                "/api/v2/redirects/find/",
-            },
-        )

--- a/tests/settings/test_discovery_filters.py
+++ b/tests/settings/test_discovery_filters.py
@@ -25,13 +25,6 @@ class TestPagesPerTypeLimit(TestCase):
                 )
             )
 
-    @override_settings(WAGTAIL_UNVEIL_PAGES_PER_TYPE=0)
-    def test_default_returns_all_pages(self):
-        urls = get_frontend_urls()
-        page_urls = [u for u in urls if u.source == "page"]
-        standard_urls = [u for u in page_urls if "StandardPage" in u.page_type]
-        self.assertEqual(len(standard_urls), 3)
-
     @override_settings(WAGTAIL_UNVEIL_PAGES_PER_TYPE=1)
     def test_limit_one_per_type(self):
         urls = get_frontend_urls()
@@ -53,7 +46,7 @@ class TestPagesPerTypeLimit(TestCase):
         self.assertEqual(standard_count, 2)
 
     @override_settings(WAGTAIL_UNVEIL_PAGES_PER_TYPE=0)
-    def test_zero_means_no_limit(self):
+    def test_zero_means_no_limit_at_frontend_discovery_layer(self):
         urls = get_frontend_urls()
         page_urls = [u for u in urls if u.source == "page"]
         standard_urls = [u for u in page_urls if "StandardPage" in u.page_type]

--- a/tests/views/test_backend_api.py
+++ b/tests/views/test_backend_api.py
@@ -56,13 +56,6 @@ class TestAdminUrlsAPIView(BaseAPIViewTestMixin, TestCase):
         )
         self.assertIsNone(response.json()["metadata"]["applied_filter"])
 
-    def test_response_includes_api_version_metadata(self):
-        response = self.client.get(
-            self.api_url,
-            HTTP_AUTHORIZATION="Bearer test-secret",
-        )
-        self.assertEqual(response.json()["metadata"]["api_version"], self.api_version)
-
     def test_page_edit_route_is_serialized_as_testable_with_resolved_route(self):
         response = self.client.get(
             self.api_url,

--- a/tests/views/test_frontend_api.py
+++ b/tests/views/test_frontend_api.py
@@ -57,13 +57,6 @@ class TestFrontendUrlsAPIView(BaseAPIViewTestMixin, TestCase):
             self.assertIn("query_params", url)
             self.assertIsInstance(url["query_params"], dict)
 
-    def test_response_includes_api_version_metadata(self):
-        response = self.client.get(
-            self.api_url,
-            HTTP_AUTHORIZATION="Bearer test-secret",
-        )
-        self.assertEqual(response.json()["metadata"]["api_version"], self.api_version)
-
     @patch("wagtail_unveil.views.get_api_contract")
     def test_response_sets_deprecation_headers_for_deprecated_contract(self, mock_get_api_contract):
         deprecated_contract = replace(


### PR DESCRIPTION
## Summary
- remove duplicate API metadata assertions already covered by shared view mixins
- merge overlapping multisite assertions into a single test
- drop redundant frontend discovery, sandbox, and admin integration tests that repeat narrower coverage
- keep the remaining no-limit settings test but rename it to clarify the discovery-layer contract

## Testing
- `uv run --env-file .env django-admin test tests.views.test_backend_api tests.views.test_frontend_api tests.settings.test_discovery_filters tests.discovery.frontend.test_multisite tests.sandbox.test_urls tests.discovery.admin.test_resolution_integration`
- `make lint`
- `make test-js`
- `make test`
- `make coverage`