### PR TITLE
Inline trivial frontend discovery helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changes merged to `main` since the last release.
 - slimmed `AGENTS.md` and moved coding, testing, documentation, and command-workflow ownership more clearly into `CONVENTIONS.md` and contributor docs
 - documented the sandbox as the intentional contributor workflow for local feature development, debugging, and realistic discovery verification
 - improved report runner pause/cancel state handling so paused runs finish correctly on the last in-flight completion and canceled runs stop queuing further work
+- inlined trivial frontend discovery and resolution helpers while keeping frontend URL discovery behavior unchanged
 
 ## 0.1.0a5 - 2026-04-02
 

--- a/tests/discovery/frontend/test_phases.py
+++ b/tests/discovery/frontend/test_phases.py
@@ -1,16 +1,33 @@
 from types import SimpleNamespace
+from unittest import mock
 
 from django.test import TestCase
 
 from wagtail_unveil.discovery.frontend import (
-    _build_frontend_url,
     _classify_frontend_candidate,
     _discover_routable_page_candidates,
     _FrontendCandidate,
+    get_frontend_urls,
 )
 
 
 class TestFrontendDiscoveryPhases(TestCase):
+    def _get_frontend_result(self, candidate):
+        with (
+            mock.patch(
+                "wagtail_unveil.discovery.frontend._discover_page_candidates",
+                return_value=[candidate],
+            ),
+            mock.patch(
+                "wagtail_unveil.discovery.frontend._discover_resolver_candidates",
+                return_value=[],
+            ),
+        ):
+            results = get_frontend_urls()
+
+        self.assertEqual(len(results), 1)
+        return results[0]
+
     def test_parameterized_resolver_candidate_with_resolved_url_is_testable(self):
         candidate = _FrontendCandidate(
             url="/api/v2/pages/<int:pk>/",
@@ -23,11 +40,12 @@ class TestFrontendDiscoveryPhases(TestCase):
         )
 
         classification = _classify_frontend_candidate(candidate)
-        result = _build_frontend_url(candidate, classification)
+        result = self._get_frontend_result(candidate)
 
         self.assertTrue(result.is_testable)
         self.assertEqual(result.skip_reason, "")
         self.assertEqual(result.resolved_url, "/api/v2/pages/2/")
+        self.assertTrue(classification.is_testable)
 
     def test_query_driven_candidate_without_query_params_is_untestable(self):
         candidate = _FrontendCandidate(
@@ -80,11 +98,12 @@ class TestFrontendDiscoveryPhases(TestCase):
         )
 
         classification = _classify_frontend_candidate(candidate)
-        result = _build_frontend_url(candidate, classification)
+        result = self._get_frontend_result(candidate)
 
         self.assertTrue(result.is_testable)
         self.assertEqual(result.skip_reason, "")
         self.assertEqual(result.resolved_url, "/events/year/2025/")
+        self.assertTrue(classification.is_testable)
 
     def test_plain_page_candidate_is_testable(self):
         candidate = _FrontendCandidate(
@@ -96,10 +115,11 @@ class TestFrontendDiscoveryPhases(TestCase):
         )
 
         classification = _classify_frontend_candidate(candidate)
-        result = _build_frontend_url(candidate, classification)
+        result = self._get_frontend_result(candidate)
 
         self.assertTrue(result.is_testable)
         self.assertEqual(result.skip_reason, "")
+        self.assertTrue(classification.is_testable)
 
     def test_form_landing_candidate_requires_post(self):
         candidate = _FrontendCandidate(

--- a/tests/discovery/frontend/test_resolution.py
+++ b/tests/discovery/frontend/test_resolution.py
@@ -9,8 +9,8 @@ from wagtail.images.tests.utils import get_test_image_file
 from wagtail.models import Site
 
 from wagtail_unveil.discovery.frontend import (
+    _classify_frontend_candidate,
     _discover_routable_page_candidates,
-    _format_cross_site_skip_reason,
     _FrontendCandidate,
     get_frontend_urls,
 )
@@ -38,7 +38,7 @@ class TestFrontendDiscoveryHelpers(TestCase):
 
         self.assertEqual(get_wagtail_api_detail_resolved_url(callback, "/api/v2/pages/<int:pk>/"), "")
 
-    def test_format_cross_site_skip_reason_with_standard_port_omits_port(self):
+    def test_classify_frontend_candidate_omits_standard_port_in_cross_site_skip_reason(self):
         candidate = _FrontendCandidate(
             url="/about/",
             source="page",
@@ -49,9 +49,10 @@ class TestFrontendDiscoveryHelpers(TestCase):
             site_port=80,
             is_cross_site=True,
         )
+        classification = _classify_frontend_candidate(candidate)
 
         self.assertEqual(
-            _format_cross_site_skip_reason(candidate),
+            classification.skip_reason,
             "Belongs to non-default site host: sub.localhost",
         )
 

--- a/wagtail_unveil/discovery/frontend.py
+++ b/wagtail_unveil/discovery/frontend.py
@@ -226,23 +226,20 @@ def _discover_resolver_candidates():
     return results
 
 
-def _format_cross_site_skip_reason(candidate):
-    """Build a skip reason for candidates that belong to a non-default site host."""
-    if not candidate.site_hostname:
-        return "Belongs to non-default site host"
-
-    if candidate.site_port and candidate.site_port not in (80, 443):
-        return f"Belongs to non-default site host: {candidate.site_hostname}:{candidate.site_port}"
-
-    return f"Belongs to non-default site host: {candidate.site_hostname}"
-
-
 def _classify_frontend_candidate(candidate):
     """Classify a frontend candidate and assign any skip reason."""
     if candidate.is_cross_site:
+        if not candidate.site_hostname:
+            skip_reason = "Belongs to non-default site host"
+        elif candidate.site_port and candidate.site_port not in (80, 443):
+            skip_reason = (
+                f"Belongs to non-default site host: {candidate.site_hostname}:{candidate.site_port}"
+            )
+        else:
+            skip_reason = f"Belongs to non-default site host: {candidate.site_hostname}"
         return _FrontendClassification(
             is_testable=False,
-            skip_reason=_format_cross_site_skip_reason(candidate),
+            skip_reason=skip_reason,
         )
     if candidate.requires_post:
         return _FrontendClassification(
@@ -266,22 +263,6 @@ def _classify_frontend_candidate(candidate):
         )
     return _FrontendClassification()
 
-
-def _build_frontend_url(candidate, classification):
-    """Emit a FrontendURL from candidate and classification state."""
-    return FrontendURL(
-        url=candidate.url,
-        source=candidate.source,
-        page_type=candidate.page_type,
-        page_title=candidate.page_title,
-        name=candidate.name,
-        resolved_url=candidate.resolved_url,
-        query_params=dict(candidate.query_params),
-        is_testable=classification.is_testable,
-        skip_reason=classification.skip_reason,
-    )
-
-
 def get_frontend_urls():
     """Discover all frontend URLs from pages and the URL resolver.
 
@@ -292,5 +273,17 @@ def get_frontend_urls():
     candidates = _discover_page_candidates() + _discover_resolver_candidates()
     for candidate in candidates:
         classification = _classify_frontend_candidate(candidate)
-        results.append(_build_frontend_url(candidate, classification))
+        results.append(
+            FrontendURL(
+                url=candidate.url,
+                source=candidate.source,
+                page_type=candidate.page_type,
+                page_title=candidate.page_title,
+                name=candidate.name,
+                resolved_url=candidate.resolved_url,
+                query_params=dict(candidate.query_params),
+                is_testable=classification.is_testable,
+                skip_reason=classification.skip_reason,
+            )
+        )
     return results

--- a/wagtail_unveil/discovery/frontend_resolution.py
+++ b/wagtail_unveil/discovery/frontend_resolution.py
@@ -42,14 +42,6 @@ def get_default_site():
     return Site.objects.filter(is_default_site=True).first()
 
 
-def _get_default_site_root_page_id():
-    """Return the default site's root page ID when available."""
-    default_site = get_default_site()
-    if default_site and default_site.root_page_id:
-        return str(default_site.root_page_id)
-    return ""
-
-
 # Routable page parameter helpers
 
 
@@ -215,7 +207,12 @@ def get_wagtail_api_detail_resolved_url(callback, url):
         return ""
 
     if callback_cls is PagesAPIViewSet:
-        page_id = _get_default_site_root_page_id() or _get_first_live_page_id()
+        default_site = get_default_site()
+        page_id = (
+            str(default_site.root_page_id)
+            if default_site and default_site.root_page_id
+            else _get_first_live_page_id()
+        )
         return url.replace("<int:pk>", page_id, 1) if page_id else ""
 
     if callback_cls is ImagesAPIViewSet:


### PR DESCRIPTION
## Summary
- inline trivial one-off helpers in frontend discovery and resolution code
- keep frontend URL discovery behavior unchanged while reducing indirection
- update the affected frontend discovery tests to match the refactor

## Testing
- `uv run --env-file .env.example django-admin test tests.discovery.frontend`