### PR TITLE
Add platform runtime API endpoint and dependency inventory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ PYTHONPATH=.
 # Absent or empty → API returns 500; wrong value → 403.
 WAGTAIL_UNVEIL_API_KEY=dev-secret
 
+# Dependency manifest used by /unveil/api/v1/platform/ for Python dependency inventory.
+# Supports BASE_DIR-relative paths such as pyproject.toml and requirements/*.txt.
+# Leave commented out to return runtime-only platform metadata with a warning.
+# WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=pyproject.toml
+
 # Limit how many pages per page type appear in frontend URL discovery.
 # 0 = no limit, positive int = limit per type, absent/invalid = 1 (default).
 # WAGTAIL_UNVEIL_PAGES_PER_TYPE=1

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ PYTHONPATH=.
 # API key for the wagtail_unveil JSON endpoints (Bearer token auth).
 # Set any non-empty string here to enable the API locally, then pass it as:
 #   Authorization: Bearer <value>
-# Absent or empty → API returns 500; wrong value → 403.
+# Absent or empty + Bearer request → 500; wrong Bearer value → 403.
+# Requests without valid Bearer auth still return 403.
 WAGTAIL_UNVEIL_API_KEY=dev-secret
 
 # Dependency manifest used by /unveil/api/v1/platform/ for Python dependency inventory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Routes provided:
 
 - `api/v1/backend-urls/` → `wagtail_unveil:api_v1_backend_urls`
 - `api/v1/frontend-urls/` → `wagtail_unveil:api_v1_frontend_urls`
+- `api/v1/platform/` → `wagtail_unveil:api_v1_platform`
 - `report/backend-urls/` → `wagtail_unveil:report_backend_urls`
 - `report/frontend-urls/` → `wagtail_unveil:report_frontend_urls`
 - `report/settings/` → `wagtail_unveil:report_settings`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes merged to `main` since the last release.
 - inlined trivial frontend discovery and resolution helpers while keeping frontend URL discovery behavior unchanged
 - hardened JSON API and report access for production use with masked settings diagnostics, constant-time bearer-key checks, private/no-store cache headers, and `WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS` support for superuser HTML reports
 - excluded private Wagtail pages from frontend discovery, tightened report-page caching for built-in production report access, and simplified shared report test helpers and documentation
+- added an authenticated `/unveil/api/v1/platform/` endpoint for runtime metadata and Python dependency inventory, including manifest warnings instead of hard failures when dependency metadata is incomplete
 
 ## 0.1.0a5 - 2026-04-02
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It exposes discovery through:
 - interactive HTML reports in Wagtail admin (superuser + `DEBUG=True`, or `WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS=True`)
 - a dedicated settings and diagnostics page in Wagtail admin (superuser + `DEBUG=True`, or `WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS=True`)
 - a dashboard panel linking to the admin report, frontend report, and settings page
+- a platform runtime API endpoint for Python/Wagtail/Django version and dependency inventory
 
 ## Quick Start
 
@@ -58,6 +59,7 @@ urlpatterns = [
 ```bash
 curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/v1/backend-urls/
 curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/v1/frontend-urls/
+curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/v1/platform/
 ```
 
 For installation details, configuration, API usage, reports, and extension recipes, use the [documentation hub](https://nm-packages.github.io/wagtail-unveil/).

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -30,6 +30,8 @@ For normal programmatic or third-party use, authenticate with `Authorization: Be
 
 Authenticated JSON responses are returned with `Cache-Control: private, no-store` and vary on `Authorization` and `Cookie`.
 
+The platform endpoint also reads `WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE` when building dependency inventory data. See [Settings Reference](../configuration/settings-reference.md#wagtail_unveil_platform_dependency_file).
+
 ## Backend URLs Endpoint
 
 Returns all discovered Wagtail admin URLs.
@@ -188,9 +190,102 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
 | `is_testable` | Whether the URL can be directly tested with a GET request |
 | `skip_reason` | Empty string for testable URLs, otherwise the reason the URL is not directly testable |
 
+## Platform Runtime Endpoint
+
+Returns runtime metadata for the current site plus a Python dependency inventory from a configured dependency manifest.
+
+```
+GET /unveil/api/v1/platform/
+```
+
+**Configuration:**
+
+- Set `WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE` to a supported manifest file such as `pyproject.toml` or `requirements.txt`
+- The endpoint still returns `200` when dependency metadata is unavailable, and reports the problem in `platform.warnings`
+
+**Examples:**
+
+```bash
+curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/v1/platform/
+```
+
+**Response:**
+
+```json
+{
+  "platform": {
+    "runtime": {
+      "python_version": "3.11.11",
+      "python_implementation": "CPython",
+      "django_version": "5.2.1",
+      "wagtail_version": "7.0.2"
+    },
+    "python_dependencies": {
+      "source": {
+        "path": "/app/pyproject.toml",
+        "format": "pyproject.toml"
+      },
+      "packages": [
+        {
+          "name": "Django",
+          "specifier": ">=5.2",
+          "installed_version": "5.2.1",
+          "is_installed": true,
+          "source_kind": "runtime",
+          "source_name": null
+        },
+        {
+          "name": "mkdocs-material",
+          "specifier": ">=9.6",
+          "installed_version": "",
+          "is_installed": false,
+          "source_kind": "group",
+          "source_name": "docs"
+        }
+      ]
+    },
+    "warnings": []
+  },
+  "metadata": {
+    "api_version": "v1",
+    "api_lifecycle": {
+      "status": "stable",
+      "deprecated_on": null,
+      "sunset_on": null
+    },
+    "generated_at": "2026-04-08T12:34:56+00:00",
+    "package_version": "0.1.0a5"
+  }
+}
+```
+
+**Platform fields:**
+
+| Field | Description |
+|---|---|
+| `platform.runtime.python_version` | Python version for the running process |
+| `platform.runtime.python_implementation` | Python implementation such as `CPython` |
+| `platform.runtime.django_version` | Installed Django version |
+| `platform.runtime.wagtail_version` | Installed Wagtail version |
+| `platform.python_dependencies.source.path` | The configured manifest path after relative-path resolution |
+| `platform.python_dependencies.source.format` | Detected manifest type: `pyproject.toml`, `poetry-pyproject`, `requirements.txt`, `unknown`, or `null` when no manifest is configured |
+| `platform.python_dependencies.packages` | Sorted list of declared Python dependency entries |
+| `platform.warnings` | Human-readable warnings when dependency metadata is incomplete or unavailable |
+
+**Dependency item fields:**
+
+| Field | Description |
+|---|---|
+| `name` | Declared package name |
+| `specifier` | Declared version specifier or source detail |
+| `installed_version` | Installed version from the current Python environment, or an empty string when not installed |
+| `is_installed` | Whether the package is installed in the current environment |
+| `source_kind` | Where the declaration came from: `runtime`, `optional`, or `group` |
+| `source_name` | Extra/group name for optional or grouped dependencies, otherwise `null` |
+
 ## Metadata
 
-Both endpoints include a `metadata` object alongside the top-level `urls` and `count` fields:
+The URL discovery endpoints include a `metadata` object alongside the top-level `urls` and `count` fields:
 
 | Field | Description |
 |---|---|
@@ -204,6 +299,8 @@ Both endpoints include a `metadata` object alongside the top-level `urls` and `c
 | `package_version` | Installed `wagtail-unveil` package version (not the API version) |
 
 If a `filter` query parameter is unrecognised, the response is not filtered and `metadata.applied_filter` is `null`.
+
+The platform endpoint also includes `metadata`, but it omits URL-discovery fields such as `applied_filter`, `total_count`, `testable_count`, and `untestable_count`.
 
 ## Deprecation Headers
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -23,7 +23,7 @@ curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api
 | Valid Bearer token | `200` with data |
 | Invalid Bearer token | `403` |
 | No key configured | `500` |
-| Superuser session + `DEBUG=True` | `200` (session auth accepted when not attempting Bearer auth) |
+| Superuser session + `DEBUG=True` | `200` for URL discovery endpoints; `/unveil/api/v1/platform/` still requires Bearer auth |
 | Superuser session + built-in production report flow | `200` when `WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS=True` |
 
 For normal programmatic or third-party use, authenticate with `Authorization: Bearer <key>`. The production superuser session path is reserved for the built-in HTML reports and settings page; it is not a general replacement for Bearer-token API access.
@@ -202,6 +202,7 @@ GET /unveil/api/v1/platform/
 
 - Set `WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE` to a supported manifest file such as `pyproject.toml` or `requirements.txt`
 - The endpoint still returns `200` when dependency metadata is unavailable, and reports the problem in `platform.warnings`
+- Unlike the URL discovery endpoints, this endpoint requires Bearer auth even when `DEBUG=True`
 
 **Examples:**
 
@@ -222,7 +223,7 @@ curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api
     },
     "python_dependencies": {
       "source": {
-        "path": "/app/pyproject.toml",
+        "path": "pyproject.toml",
         "format": "pyproject.toml"
       },
       "packages": [
@@ -267,10 +268,10 @@ curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api
 | `platform.runtime.python_implementation` | Python implementation such as `CPython` |
 | `platform.runtime.django_version` | Installed Django version |
 | `platform.runtime.wagtail_version` | Installed Wagtail version |
-| `platform.python_dependencies.source.path` | The configured manifest path after relative-path resolution |
+| `platform.python_dependencies.source.path` | Basename of the configured manifest file, such as `pyproject.toml` or `base.txt` |
 | `platform.python_dependencies.source.format` | Detected manifest type: `pyproject.toml`, `poetry-pyproject`, `requirements.txt`, `unknown`, or `null` when no manifest is configured |
 | `platform.python_dependencies.packages` | Sorted list of declared Python dependency entries |
-| `platform.warnings` | Human-readable warnings when dependency metadata is incomplete or unavailable |
+| `platform.warnings` | Human-readable warnings when dependency metadata is incomplete or unavailable; warnings do not include internal paths or raw exception details |
 
 **Dependency item fields:**
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -14,6 +14,9 @@ curl -H "Authorization: Bearer your-key" http://localhost:8000/unveil/api/v1/bac
 
 # Frontend URLs
 curl -H "Authorization: Bearer your-key" http://localhost:8000/unveil/api/v1/frontend-urls/
+
+# Platform runtime and dependency inventory
+curl -H "Authorization: Bearer your-key" http://localhost:8000/unveil/api/v1/platform/
 ```
 
 ## Related

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -12,6 +12,7 @@ wagtail-unveil is configured via Django settings or environment variables.
 |---|---|---|
 | `WAGTAIL_UNVEIL_API_KEY` | — | Bearer token for JSON API authentication |
 | `WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS` | `False` | Explicit opt-in for superuser HTML report access when `DEBUG=False` |
+| `WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE` | — | Dependency manifest used by the platform runtime API |
 | `WAGTAIL_UNVEIL_PAGES_PER_TYPE` | `1` | Max page instances per type in frontend discovery |
 | `WAGTAIL_UNVEIL_SKIP_URL_PREFIXES` | `[]` | URL prefixes to exclude from discovery |
 

--- a/docs/configuration/settings-reference.md
+++ b/docs/configuration/settings-reference.md
@@ -62,7 +62,7 @@ WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE = "pyproject.toml"
 
 - If both are set, the environment variable is used
 - Blank or non-string values are treated as unset
-- Relative paths are resolved from Django `BASE_DIR`
+- Relative paths are resolved from Django `BASE_DIR` and must stay within that directory
 - Absolute paths are used directly
 - Supported formats in v1 are `pyproject.toml` and requirements-style text files
 - If the setting is unset, unreadable, missing, or unsupported, the platform endpoint still returns runtime data and adds a warning instead of failing the whole response

--- a/docs/configuration/settings-reference.md
+++ b/docs/configuration/settings-reference.md
@@ -45,6 +45,28 @@ WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS = True
 - Does not make the JSON API broadly session-authenticated in production
 - The report UI uses a short-lived signed token for its own JSON requests; the API key is still never exposed to the browser
 
+## `WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE`
+
+The dependency manifest used by `/unveil/api/v1/platform/` to report declared Python dependencies and their installed versions.
+
+```bash
+export WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=pyproject.toml
+export WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=requirements/base.txt
+```
+
+```python
+WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE = "pyproject.toml"
+```
+
+**Notes:**
+
+- If both are set, the environment variable is used
+- Blank or non-string values are treated as unset
+- Relative paths are resolved from Django `BASE_DIR`
+- Absolute paths are used directly
+- Supported formats in v1 are `pyproject.toml` and requirements-style text files
+- If the setting is unset, unreadable, missing, or unsupported, the platform endpoint still returns runtime data and adds a warning instead of failing the whole response
+
 ## `WAGTAIL_UNVEIL_PAGES_PER_TYPE`
 
 Controls how many page instances per page type are included in frontend URL discovery.
@@ -93,6 +115,7 @@ WAGTAIL_UNVEIL_SKIP_URL_PREFIXES = ["__debug__/", "/silk/"]
 ## Related
 
 - [Getting Started](../getting-started/installation.md) — Initial setup and API key configuration
+- [API Endpoints](../api/endpoints.md) — Platform runtime and URL discovery API payloads
 - [Frontend URLs Report](../features/frontend-urls-report.md) — How page limits affect the report
 - [Settings Page](../features/settings-page.md) — View effective values at runtime
 - [Configuration Index](index.md) — Back to section overview

--- a/docs/features/settings-page.md
+++ b/docs/features/settings-page.md
@@ -16,6 +16,7 @@ You can also reach it from the Wagtail admin dashboard panel.
 
 - `WAGTAIL_UNVEIL_API_KEY` — shown in masked form so the secret is never rendered in full
 - `WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS`
+- `WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE`
 - `WAGTAIL_UNVEIL_PAGES_PER_TYPE`
 - `WAGTAIL_UNVEIL_SKIP_URL_PREFIXES`
 
@@ -31,7 +32,7 @@ Each value also shows its source: environment variable, Django settings, or pack
 **Package information:**
 
 - Package version and Python/Django/Wagtail runtime versions
-- Resolved Unveil API and report URLs as registered in the URL config
+- Resolved Unveil API and report URLs as registered in the URL config, including the platform runtime API
 
 ## Related
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -71,11 +71,18 @@ You can also open these pages from links in the Wagtail admin dashboard panel.
 ```bash
 curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/v1/backend-urls/
 curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/v1/frontend-urls/
+curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api/v1/platform/
+```
+
+To include Python dependency inventory in the platform response, also set:
+
+```python
+WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE = "pyproject.toml"
 ```
 
 ## Related
 
-- [Configuration](../configuration/settings-reference.md) — Customise page limits and URL exclusions
+- [Configuration](../configuration/settings-reference.md) — Customise API, platform, and discovery settings
 - [Features](../features/index.md) — Explore what the reports can do
 - [API Reference](../api/endpoints.md) — Full API endpoint documentation
 - [Getting Started Index](index.md) — Back to section overview

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -80,6 +80,8 @@ To include Python dependency inventory in the platform response, also set:
 WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE = "pyproject.toml"
 ```
 
+The platform endpoint always requires Bearer auth, even in local `DEBUG=True` development.
+
 ## Related
 
 - [Configuration](../configuration/settings-reference.md) — Customise API, platform, and discovery settings

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,8 @@ This is the canonical documentation hub for `wagtail-unveil`.
 
 - [Getting Started](getting-started/index.md) — Canonical starting point for installation, quick start, and first-time setup.
 - [Features](features/index.md) — Canonical user-facing guide to reports, the settings page, and the dashboard panel.
-- [Configuration](configuration/index.md) — Canonical reference for package settings and API key configuration.
-- [API Reference](api/index.md) — Canonical reference for versioned JSON API endpoints, auth, and response shape.
+- [Configuration](configuration/index.md) — Canonical reference for package settings, API key configuration, and platform dependency manifest configuration.
+- [API Reference](api/index.md) — Canonical reference for versioned JSON API endpoints, including URL discovery and platform runtime metadata.
 - [Recipes](recipes/index.md) — Task-focused guides for extending `wagtail-unveil` in your own project.
 
 ## Contribute / maintain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "django>=4.2",
+    "tomli>=2.0.0; python_version < '3.11'",
     "wagtail>=7.0",
 ]
 

--- a/tests/api/test_api_contract.py
+++ b/tests/api/test_api_contract.py
@@ -21,8 +21,10 @@ def _contract(
     status,
     backend_path,
     frontend_path,
+    platform_path=None,
     backend_name,
     frontend_name,
+    platform_name=None,
     deprecated_on=None,
     sunset_on=None,
 ):
@@ -33,8 +35,10 @@ def _contract(
         sunset_on=sunset_on,
         backend_url_path=backend_path,
         frontend_url_path=frontend_path,
+        platform_url_path=platform_path or f"api/{version}/platform/",
         backend_url_name=backend_name,
         frontend_url_name=frontend_name,
+        platform_url_name=platform_name or f"api_{version}_platform",
     )
 
 
@@ -75,6 +79,33 @@ class TestAPIContractRegistry(SimpleTestCase):
         with self.assertRaises(ValueError):
             validate_api_version_registry(registry)
 
+    def test_validate_registry_rejects_duplicate_platform_paths(self):
+        registry = {
+            "v1": _contract(
+                version="v1",
+                status="stable",
+                backend_path="api/v1/backend-urls/",
+                frontend_path="api/v1/frontend-urls/",
+                platform_path="api/v1/platform/",
+                backend_name="api_v1_backend_urls",
+                frontend_name="api_v1_frontend_urls",
+                platform_name="api_v1_platform",
+            ),
+            "v2": _contract(
+                version="v2",
+                status="deprecated",
+                backend_path="api/v2/backend-urls/",
+                frontend_path="api/v2/frontend-urls/",
+                platform_path="api/v1/platform/",
+                backend_name="api_v2_backend_urls",
+                frontend_name="api_v2_frontend_urls",
+                platform_name="api_v2_platform",
+            ),
+        }
+
+        with self.assertRaises(ValueError):
+            validate_api_version_registry(registry)
+
     def test_validate_registry_rejects_duplicate_names(self):
         registry = {
             "v1": _contract(
@@ -92,6 +123,33 @@ class TestAPIContractRegistry(SimpleTestCase):
                 frontend_path="api/v2/frontend-urls/",
                 backend_name="api_v2_backend_urls",
                 frontend_name="api_v1_frontend_urls",
+            ),
+        }
+
+        with self.assertRaises(ValueError):
+            validate_api_version_registry(registry)
+
+    def test_validate_registry_rejects_duplicate_platform_names(self):
+        registry = {
+            "v1": _contract(
+                version="v1",
+                status="stable",
+                backend_path="api/v1/backend-urls/",
+                frontend_path="api/v1/frontend-urls/",
+                platform_path="api/v1/platform/",
+                backend_name="api_v1_backend_urls",
+                frontend_name="api_v1_frontend_urls",
+                platform_name="api_v1_platform",
+            ),
+            "v2": _contract(
+                version="v2",
+                status="deprecated",
+                backend_path="api/v2/backend-urls/",
+                frontend_path="api/v2/frontend-urls/",
+                platform_path="api/v2/platform/",
+                backend_name="api_v2_backend_urls",
+                frontend_name="api_v2_frontend_urls",
+                platform_name="api_v1_platform",
             ),
         }
 
@@ -268,7 +326,7 @@ class TestAPIContractRegistry(SimpleTestCase):
 
 
 class TestAPIVersionRouting(SimpleTestCase):
-    def test_all_supported_versions_have_backend_and_frontend_routes(self):
+    def test_all_supported_versions_have_backend_frontend_and_platform_routes(self):
         for api_version in get_supported_api_versions():
             contract = get_api_contract(api_version)
             self.assertEqual(
@@ -278,6 +336,10 @@ class TestAPIVersionRouting(SimpleTestCase):
             self.assertEqual(
                 reverse(f"wagtail_unveil:{contract.frontend_url_name}"),
                 f"/unveil/{contract.frontend_url_path}",
+            )
+            self.assertEqual(
+                reverse(f"wagtail_unveil:{contract.platform_url_name}"),
+                f"/unveil/{contract.platform_url_path}",
             )
 
     def test_v1_url_names_remain_resolvable(self):
@@ -290,6 +352,10 @@ class TestAPIVersionRouting(SimpleTestCase):
             reverse(f"wagtail_unveil:{contract.frontend_url_name}"),
             "/unveil/api/v1/frontend-urls/",
         )
+        self.assertEqual(
+            reverse(f"wagtail_unveil:{contract.platform_url_name}"),
+            "/unveil/api/v1/platform/",
+        )
 
     def test_unversioned_alias_names_are_not_exposed(self):
         with self.assertRaises(NoReverseMatch):
@@ -297,6 +363,9 @@ class TestAPIVersionRouting(SimpleTestCase):
 
         with self.assertRaises(NoReverseMatch):
             reverse("wagtail_unveil:api_frontend_urls")
+
+        with self.assertRaises(NoReverseMatch):
+            reverse("wagtail_unveil:api_platform")
 
 
 class TestAPIContractAccessors(SimpleTestCase):

--- a/tests/platform/test_platform_data.py
+++ b/tests/platform/test_platform_data.py
@@ -1,0 +1,244 @@
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from wagtail_unveil.platform_data import get_platform_snapshot
+
+
+class TestPlatformSnapshot(SimpleTestCase):
+    def test_no_manifest_configured_returns_warning(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with override_settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=""):
+                snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.dependency_source.path, "")
+        self.assertIsNone(snapshot.dependency_source.format)
+        self.assertEqual(snapshot.python_dependencies, [])
+        self.assertEqual(snapshot.warnings, ["No dependency manifest is configured."])
+
+    def test_relative_path_resolves_from_base_dir_for_requirements_files(self):
+        with TemporaryDirectory() as tempdir:
+            base_dir = Path(tempdir)
+            manifest_path = base_dir / "requirements" / "base.txt"
+            manifest_path.parent.mkdir()
+            manifest_path.write_text("Django>=5.2\nwagtail==7.0\n", encoding="utf-8")
+
+            with override_settings(
+                BASE_DIR=base_dir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="requirements/base.txt",
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch(
+                        "wagtail_unveil.platform_data.version",
+                        side_effect=lambda name: {"Django": "5.2.1", "wagtail": "7.0.2"}[name],
+                    ):
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.dependency_source.path, str(manifest_path))
+        self.assertEqual(snapshot.dependency_source.format, "requirements.txt")
+        self.assertEqual(
+            [dependency.name for dependency in snapshot.python_dependencies],
+            ["Django", "wagtail"],
+        )
+        self.assertEqual(snapshot.python_dependencies[0].installed_version, "5.2.1")
+        self.assertEqual(snapshot.python_dependencies[1].installed_version, "7.0.2")
+
+    def test_env_var_wins_over_django_setting_for_manifest_path(self):
+        with TemporaryDirectory() as tempdir:
+            base_dir = Path(tempdir)
+            env_manifest_path = base_dir / "requirements.txt"
+            env_manifest_path.write_text("Django>=5.2\n", encoding="utf-8")
+
+            with override_settings(
+                BASE_DIR=base_dir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="ignored.txt",
+            ):
+                with patch.dict(
+                    "os.environ",
+                    {"WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE": str(env_manifest_path)},
+                    clear=True,
+                ):
+                    with patch("wagtail_unveil.platform_data.version", return_value="5.2.1"):
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.dependency_source.path, str(env_manifest_path))
+        self.assertEqual(snapshot.python_dependencies[0].name, "Django")
+
+    def test_standard_pyproject_includes_runtime_optional_and_dependency_groups(self):
+        with TemporaryDirectory() as tempdir:
+            manifest_path = Path(tempdir) / "pyproject.toml"
+            manifest_path.write_text(
+                """
+[project]
+name = "demo"
+version = "0.1.0"
+dependencies = ["wagtail>=7.0", "Django>=5.2"]
+
+[project.optional-dependencies]
+docs = ["mkdocs>=1.6"]
+
+[dependency-groups]
+dev = ["ruff>=0.9", {include-group = "docs-tools"}]
+docs-tools = ["mkdocs-material>=9.6"]
+""".strip(),
+                encoding="utf-8",
+            )
+
+            versions = {
+                "Django": "5.2.1",
+                "mkdocs": "1.6.1",
+                "mkdocs-material": "9.6.0",
+                "ruff": "0.9.2",
+                "wagtail": "7.0.2",
+            }
+            with override_settings(
+                BASE_DIR=tempdir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch("wagtail_unveil.platform_data.version", side_effect=lambda name: versions[name]):
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.dependency_source.format, "pyproject.toml")
+        self.assertEqual(
+            [dependency.name for dependency in snapshot.python_dependencies],
+            ["Django", "mkdocs", "mkdocs-material", "mkdocs-material", "ruff", "wagtail"],
+        )
+        self.assertEqual(snapshot.python_dependencies[0].source_kind, "runtime")
+        self.assertEqual(snapshot.python_dependencies[1].source_kind, "optional")
+        self.assertEqual(snapshot.python_dependencies[1].source_name, "docs")
+        self.assertEqual(snapshot.python_dependencies[2].source_kind, "group")
+        self.assertEqual(snapshot.python_dependencies[2].source_name, "dev")
+        self.assertEqual(snapshot.python_dependencies[3].source_kind, "group")
+        self.assertEqual(snapshot.python_dependencies[3].source_name, "docs-tools")
+        self.assertEqual(snapshot.python_dependencies[4].source_kind, "group")
+        self.assertEqual(snapshot.python_dependencies[4].source_name, "dev")
+
+    def test_poetry_pyproject_includes_runtime_extra_and_group_dependencies(self):
+        with TemporaryDirectory() as tempdir:
+            manifest_path = Path(tempdir) / "pyproject.toml"
+            manifest_path.write_text(
+                """
+[tool.poetry]
+name = "demo"
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+django = "^5.2"
+sentry-sdk = { version = "^2.0", optional = true }
+
+[tool.poetry.extras]
+monitoring = ["sentry-sdk"]
+
+[tool.poetry.group.dev.dependencies]
+ruff = "^0.9"
+""".strip(),
+                encoding="utf-8",
+            )
+
+            versions = {
+                "django": "5.2.1",
+                "ruff": "0.9.2",
+                "sentry-sdk": "2.21.0",
+            }
+            with override_settings(
+                BASE_DIR=tempdir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch("wagtail_unveil.platform_data.version", side_effect=lambda name: versions[name]):
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.dependency_source.format, "poetry-pyproject")
+        self.assertEqual(
+            [dependency.name for dependency in snapshot.python_dependencies],
+            ["django", "ruff", "sentry-sdk"],
+        )
+        self.assertEqual(snapshot.python_dependencies[0].source_kind, "runtime")
+        self.assertEqual(snapshot.python_dependencies[1].source_kind, "group")
+        self.assertEqual(snapshot.python_dependencies[1].source_name, "dev")
+        self.assertEqual(snapshot.python_dependencies[2].source_kind, "optional")
+        self.assertEqual(snapshot.python_dependencies[2].source_name, "monitoring")
+
+    def test_missing_installed_package_is_marked_uninstalled(self):
+        with TemporaryDirectory() as tempdir:
+            manifest_path = Path(tempdir) / "requirements.txt"
+            manifest_path.write_text("missing-package>=1.0\n", encoding="utf-8")
+
+            with override_settings(
+                BASE_DIR=tempdir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch(
+                        "wagtail_unveil.platform_data.version",
+                        side_effect=PackageNotFoundError,
+                    ):
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.python_dependencies[0].installed_version, "")
+        self.assertFalse(snapshot.python_dependencies[0].is_installed)
+
+    def test_missing_manifest_returns_warning(self):
+        with TemporaryDirectory() as tempdir:
+            missing_path = Path(tempdir) / "missing.txt"
+            with override_settings(
+                BASE_DIR=tempdir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(missing_path),
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.python_dependencies, [])
+        self.assertIn("does not exist", snapshot.warnings[0])
+
+    def test_unreadable_manifest_returns_warning(self):
+        with TemporaryDirectory() as tempdir:
+            manifest_path = Path(tempdir) / "requirements.txt"
+            manifest_path.write_text("Django>=5.2\n", encoding="utf-8")
+
+            with override_settings(
+                BASE_DIR=tempdir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch("pathlib.Path.read_text", side_effect=PermissionError("denied")):
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.python_dependencies, [])
+        self.assertIn("Could not read dependency manifest", snapshot.warnings[0])
+
+    def test_unparseable_pyproject_returns_warning(self):
+        with TemporaryDirectory() as tempdir:
+            manifest_path = Path(tempdir) / "pyproject.toml"
+            manifest_path.write_text("[project\nbroken = true\n", encoding="utf-8")
+
+            with override_settings(
+                BASE_DIR=tempdir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.python_dependencies, [])
+        self.assertIn("Could not read dependency manifest", snapshot.warnings[0])
+
+    def test_unsupported_manifest_returns_warning(self):
+        with TemporaryDirectory() as tempdir:
+            manifest_path = Path(tempdir) / "deps.lock"
+            manifest_path.write_text("{}", encoding="utf-8")
+
+            with override_settings(
+                BASE_DIR=tempdir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.dependency_source.format, "unknown")
+        self.assertEqual(snapshot.python_dependencies, [])
+        self.assertIn("Unsupported dependency manifest format", snapshot.warnings[0])

--- a/tests/platform/test_platform_data.py
+++ b/tests/platform/test_platform_data.py
@@ -37,7 +37,7 @@ class TestPlatformSnapshot(SimpleTestCase):
                     ):
                         snapshot = get_platform_snapshot()
 
-        self.assertEqual(snapshot.dependency_source.path, str(manifest_path))
+        self.assertEqual(snapshot.dependency_source.path, "base.txt")
         self.assertEqual(snapshot.dependency_source.format, "requirements.txt")
         self.assertEqual(
             [dependency.name for dependency in snapshot.python_dependencies],
@@ -64,8 +64,30 @@ class TestPlatformSnapshot(SimpleTestCase):
                     with patch("wagtail_unveil.platform_data.version", return_value="5.2.1"):
                         snapshot = get_platform_snapshot()
 
-        self.assertEqual(snapshot.dependency_source.path, str(env_manifest_path))
+        self.assertEqual(snapshot.dependency_source.path, "requirements.txt")
         self.assertEqual(snapshot.python_dependencies[0].name, "Django")
+
+    def test_relative_path_outside_base_dir_is_rejected(self):
+        with TemporaryDirectory() as tempdir:
+            base_dir = Path(tempdir) / "project"
+            base_dir.mkdir()
+
+            with override_settings(
+                BASE_DIR=base_dir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="../../etc/passwd",
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch("wagtail_unveil.platform_data.logger.warning") as mock_warning:
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.dependency_source.path, "")
+        self.assertIsNone(snapshot.dependency_source.format)
+        self.assertEqual(snapshot.python_dependencies, [])
+        self.assertEqual(
+            snapshot.warnings,
+            ["Dependency manifest must stay within BASE_DIR when configured relatively."],
+        )
+        mock_warning.assert_called_once()
 
     def test_standard_pyproject_includes_runtime_optional_and_dependency_groups(self):
         with TemporaryDirectory() as tempdir:
@@ -116,6 +138,36 @@ docs-tools = ["mkdocs-material>=9.6"]
         self.assertEqual(snapshot.python_dependencies[3].source_name, "docs-tools")
         self.assertEqual(snapshot.python_dependencies[4].source_kind, "group")
         self.assertEqual(snapshot.python_dependencies[4].source_name, "dev")
+
+    def test_pyproject_is_read_once(self):
+        with TemporaryDirectory() as tempdir:
+            manifest_path = Path(tempdir) / "pyproject.toml"
+            manifest_path.write_text(
+                """
+[project]
+name = "demo"
+version = "0.1.0"
+dependencies = ["Django>=5.2"]
+""".strip(),
+                encoding="utf-8",
+            )
+
+            with override_settings(
+                BASE_DIR=tempdir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch("wagtail_unveil.platform_data.version", return_value="5.2.1"):
+                        with patch.object(
+                            Path,
+                            "read_text",
+                            autospec=True,
+                            side_effect=Path.read_text,
+                        ) as mock_read_text:
+                            snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.dependency_source.format, "pyproject.toml")
+        self.assertEqual(mock_read_text.call_count, 1)
 
     def test_poetry_pyproject_includes_runtime_extra_and_group_dependencies(self):
         with TemporaryDirectory() as tempdir:
@@ -191,10 +243,12 @@ ruff = "^0.9"
                 WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(missing_path),
             ):
                 with patch.dict("os.environ", {}, clear=True):
-                    snapshot = get_platform_snapshot()
+                    with patch("wagtail_unveil.platform_data.logger.warning") as mock_warning:
+                        snapshot = get_platform_snapshot()
 
         self.assertEqual(snapshot.python_dependencies, [])
-        self.assertIn("does not exist", snapshot.warnings[0])
+        self.assertEqual(snapshot.warnings, ["Dependency manifest is missing or inaccessible."])
+        mock_warning.assert_called_once()
 
     def test_unreadable_manifest_returns_warning(self):
         with TemporaryDirectory() as tempdir:
@@ -207,10 +261,13 @@ ruff = "^0.9"
             ):
                 with patch.dict("os.environ", {}, clear=True):
                     with patch("pathlib.Path.read_text", side_effect=PermissionError("denied")):
-                        snapshot = get_platform_snapshot()
+                        with patch("wagtail_unveil.platform_data.logger.warning") as mock_warning:
+                            snapshot = get_platform_snapshot()
 
         self.assertEqual(snapshot.python_dependencies, [])
-        self.assertIn("Could not read dependency manifest", snapshot.warnings[0])
+        self.assertEqual(snapshot.warnings, ["Dependency manifest is missing or inaccessible."])
+        logged_message = mock_warning.call_args[0][0]
+        self.assertIn("Failed to inspect dependency manifest", logged_message)
 
     def test_unparseable_pyproject_returns_warning(self):
         with TemporaryDirectory() as tempdir:
@@ -222,10 +279,12 @@ ruff = "^0.9"
                 WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
             ):
                 with patch.dict("os.environ", {}, clear=True):
-                    snapshot = get_platform_snapshot()
+                    with patch("wagtail_unveil.platform_data.logger.warning") as mock_warning:
+                        snapshot = get_platform_snapshot()
 
         self.assertEqual(snapshot.python_dependencies, [])
-        self.assertIn("Could not read dependency manifest", snapshot.warnings[0])
+        self.assertEqual(snapshot.warnings, ["Dependency manifest could not be parsed."])
+        self.assertIn("Failed to inspect dependency manifest", mock_warning.call_args[0][0])
 
     def test_unsupported_manifest_returns_warning(self):
         with TemporaryDirectory() as tempdir:
@@ -237,8 +296,39 @@ ruff = "^0.9"
                 WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
             ):
                 with patch.dict("os.environ", {}, clear=True):
-                    snapshot = get_platform_snapshot()
+                    with patch("wagtail_unveil.platform_data.logger.warning") as mock_warning:
+                        snapshot = get_platform_snapshot()
 
         self.assertEqual(snapshot.dependency_source.format, "unknown")
         self.assertEqual(snapshot.python_dependencies, [])
-        self.assertIn("Unsupported dependency manifest format", snapshot.warnings[0])
+        self.assertEqual(snapshot.warnings, ["Dependency manifest format is unsupported."])
+        mock_warning.assert_called_once()
+
+    def test_duplicate_sibling_include_group_is_warned_once_and_not_duplicated(self):
+        with TemporaryDirectory() as tempdir:
+            manifest_path = Path(tempdir) / "pyproject.toml"
+            manifest_path.write_text(
+                """
+[project]
+name = "demo"
+version = "0.1.0"
+
+[dependency-groups]
+dev = [{include-group = "shared"}, {include-group = "shared"}]
+shared = ["ruff>=0.9"]
+""".strip(),
+                encoding="utf-8",
+            )
+
+            with override_settings(
+                BASE_DIR=tempdir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch("wagtail_unveil.platform_data.version", return_value="0.9.2"):
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual([dependency.name for dependency in snapshot.python_dependencies], ["ruff", "ruff"])
+        self.assertEqual(snapshot.python_dependencies[0].source_name, "dev")
+        self.assertEqual(snapshot.python_dependencies[1].source_name, "shared")
+        self.assertEqual(snapshot.warnings, ["Skipped duplicate dependency group reference for 'shared'."])

--- a/tests/platform/test_platform_data.py
+++ b/tests/platform/test_platform_data.py
@@ -235,6 +235,34 @@ ruff = "^0.9"
         self.assertEqual(snapshot.python_dependencies[0].installed_version, "")
         self.assertFalse(snapshot.python_dependencies[0].is_installed)
 
+    def test_requirements_vcs_dependency_preserves_egg_fragment_name(self):
+        with TemporaryDirectory() as tempdir:
+            manifest_path = Path(tempdir) / "requirements.txt"
+            manifest_path.write_text(
+                "git+https://github.com/example/pkg.git@main#egg=example-pkg\n",
+                encoding="utf-8",
+            )
+
+            with override_settings(
+                BASE_DIR=tempdir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch("wagtail_unveil.platform_data.version", return_value="1.2.3"):
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual(
+            [
+                (
+                    dependency.name,
+                    dependency.specifier,
+                )
+                for dependency in snapshot.python_dependencies
+            ],
+            [("example-pkg", "git+https://github.com/example/pkg.git@main#egg=example-pkg")],
+        )
+        self.assertEqual(snapshot.warnings, [])
+
     def test_missing_manifest_returns_warning(self):
         with TemporaryDirectory() as tempdir:
             missing_path = Path(tempdir) / "missing.txt"
@@ -332,3 +360,28 @@ shared = ["ruff>=0.9"]
         self.assertEqual(snapshot.python_dependencies[0].source_name, "dev")
         self.assertEqual(snapshot.python_dependencies[1].source_name, "shared")
         self.assertEqual(snapshot.warnings, ["Skipped duplicate dependency group reference for 'shared'."])
+
+    def test_missing_include_group_reference_adds_warning(self):
+        with TemporaryDirectory() as tempdir:
+            manifest_path = Path(tempdir) / "pyproject.toml"
+            manifest_path.write_text(
+                """
+[project]
+name = "demo"
+version = "0.1.0"
+
+[dependency-groups]
+dev = [{include-group = "docs-tool"}]
+""".strip(),
+                encoding="utf-8",
+            )
+
+            with override_settings(
+                BASE_DIR=tempdir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    snapshot = get_platform_snapshot()
+
+        self.assertEqual(snapshot.python_dependencies, [])
+        self.assertEqual(snapshot.warnings, ["Skipped missing dependency group reference for 'docs-tool'."])

--- a/tests/settings/test_diagnostics.py
+++ b/tests/settings/test_diagnostics.py
@@ -164,3 +164,31 @@ class TestSettingDiagnostics(TestCase):
         self.assertEqual(diagnostic.source, "django")
         self.assertEqual(diagnostic.effective_value, "")
         self.assertIn("leave Bearer authentication unconfigured", diagnostic.notes)
+
+    def test_platform_dependency_file_diagnostics_use_default_source_when_unset(self):
+        with patch("wagtail_unveil.settings.settings", SimpleNamespace()):
+            with patch.dict("os.environ", {}, clear=True):
+                diagnostic = self._get_diagnostic("WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE")
+
+        self.assertEqual(diagnostic.source, "default")
+        self.assertEqual(diagnostic.raw_display, "Not set")
+        self.assertEqual(diagnostic.effective_value, "")
+        self.assertIn("unconfigured", diagnostic.notes)
+
+    @override_settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="  requirements/base.txt  ")
+    def test_platform_dependency_file_diagnostics_note_whitespace_stripping(self):
+        with patch.dict("os.environ", {}, clear=True):
+            diagnostic = self._get_diagnostic("WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE")
+
+        self.assertEqual(diagnostic.source, "django")
+        self.assertEqual(diagnostic.effective_value, "requirements/base.txt")
+        self.assertIn("whitespace is stripped", diagnostic.notes)
+
+    @override_settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="settings.txt")
+    def test_platform_dependency_file_diagnostics_prefer_env_source(self):
+        with patch.dict("os.environ", {"WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE": "pyproject.toml"}):
+            diagnostic = self._get_diagnostic("WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE")
+
+        self.assertEqual(diagnostic.source, "env")
+        self.assertEqual(diagnostic.raw_value, "pyproject.toml")
+        self.assertEqual(diagnostic.effective_value, "pyproject.toml")

--- a/tests/settings/test_diagnostics.py
+++ b/tests/settings/test_diagnostics.py
@@ -137,6 +137,14 @@ class TestSettingDiagnostics(TestCase):
         self.assertEqual(diagnostic.effective_value, "")
         self.assertIn("Blank environment values are ignored.", diagnostic.notes)
 
+    def test_whitespace_only_api_key_env_value_is_ignored(self):
+        with patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "   "}):
+            diagnostic = self._get_diagnostic("WAGTAIL_UNVEIL_API_KEY")
+
+        self.assertEqual(diagnostic.source, "env")
+        self.assertEqual(diagnostic.effective_value, "")
+        self.assertIn("Blank environment values are ignored.", diagnostic.notes)
+
     @override_settings(WAGTAIL_UNVEIL_API_KEY=True)
     def test_non_string_api_key_value_is_reported_as_invalid(self):
         with patch.dict("os.environ", {}, clear=True):

--- a/tests/settings/test_runtime_settings.py
+++ b/tests/settings/test_runtime_settings.py
@@ -155,6 +155,11 @@ class TestGetApiKey(TestCase):
                 self.assertEqual(get_api_key(), "")
 
     @override_settings(WAGTAIL_UNVEIL_API_KEY="django-setting-key")
+    def test_whitespace_env_var_falls_back_to_django_setting(self):
+        with patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "   "}):
+            self.assertEqual(get_api_key(), "django-setting-key")
+
+    @override_settings(WAGTAIL_UNVEIL_API_KEY="django-setting-key")
     def test_django_setting_fallback_when_env_var_absent(self):
         with patch.dict("os.environ", {}, clear=True):
             self.assertEqual(get_api_key(), "django-setting-key")
@@ -178,6 +183,7 @@ class TestGetApiKey(TestCase):
     def test_env_var_wins_over_django_setting(self):
         with patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "env-key"}):
             self.assertEqual(get_api_key(), "env-key")
+
 
 class TestGetEnableProductionReports(TestCase):
     def test_missing_setting_defaults_to_false(self):
@@ -251,6 +257,11 @@ class TestGetPlatformDependencyFile(TestCase):
         with patch("wagtail_unveil.settings.settings", SimpleNamespace()):
             with patch.dict("os.environ", {"WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE": ""}):
                 self.assertEqual(get_platform_dependency_file(), "")
+
+    @override_settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="requirements/dev.txt")
+    def test_whitespace_env_var_falls_back_to_django_setting(self):
+        with patch.dict("os.environ", {"WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE": "   "}):
+            self.assertEqual(get_platform_dependency_file(), "requirements/dev.txt")
 
     @override_settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="requirements/dev.txt")
     def test_django_setting_fallback_when_env_var_absent(self):

--- a/tests/settings/test_runtime_settings.py
+++ b/tests/settings/test_runtime_settings.py
@@ -8,6 +8,7 @@ from wagtail_unveil.settings import (
     get_api_key,
     get_enable_production_reports,
     get_pages_per_type,
+    get_platform_dependency_file,
     get_skip_url_prefixes,
     is_report_ui_enabled,
 )
@@ -178,7 +179,6 @@ class TestGetApiKey(TestCase):
         with patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "env-key"}):
             self.assertEqual(get_api_key(), "env-key")
 
-
 class TestGetEnableProductionReports(TestCase):
     def test_missing_setting_defaults_to_false(self):
         with patch("wagtail_unveil.settings.settings", SimpleNamespace()):
@@ -231,3 +231,43 @@ class TestIsReportUiEnabled(TestCase):
     @override_settings(DEBUG=False, WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS=False)
     def test_disabled_when_debug_and_opt_in_are_false(self):
         self.assertFalse(is_report_ui_enabled())
+
+
+class TestGetPlatformDependencyFile(TestCase):
+    def test_missing_env_and_missing_setting_returns_empty_string(self):
+        with patch("wagtail_unveil.settings.settings", SimpleNamespace()):
+            with patch.dict("os.environ", {}, clear=True):
+                self.assertEqual(get_platform_dependency_file(), "")
+
+    def test_env_var_non_empty_string_returned(self):
+        with patch.dict("os.environ", {"WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE": "requirements/base.txt"}):
+            self.assertEqual(get_platform_dependency_file(), "requirements/base.txt")
+
+    def test_env_var_strips_whitespace(self):
+        with patch.dict("os.environ", {"WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE": "  pyproject.toml  "}):
+            self.assertEqual(get_platform_dependency_file(), "pyproject.toml")
+
+    def test_env_var_empty_string_returns_empty_string(self):
+        with patch("wagtail_unveil.settings.settings", SimpleNamespace()):
+            with patch.dict("os.environ", {"WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE": ""}):
+                self.assertEqual(get_platform_dependency_file(), "")
+
+    @override_settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="requirements/dev.txt")
+    def test_django_setting_fallback_when_env_var_absent(self):
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertEqual(get_platform_dependency_file(), "requirements/dev.txt")
+
+    @override_settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=None)
+    def test_django_setting_none_returns_empty_string(self):
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertEqual(get_platform_dependency_file(), "")
+
+    @override_settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=True)
+    def test_django_setting_bool_returns_empty_string(self):
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertEqual(get_platform_dependency_file(), "")
+
+    @override_settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="requirements/base.txt")
+    def test_env_var_wins_over_django_setting(self):
+        with patch.dict("os.environ", {"WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE": "pyproject.toml"}):
+            self.assertEqual(get_platform_dependency_file(), "pyproject.toml")

--- a/tests/views/test_platform_api.py
+++ b/tests/views/test_platform_api.py
@@ -19,6 +19,7 @@ class TestPlatformAPIView(TestCase):
     def _write_manifest(self, content: str, filename: str = "requirements.txt") -> tuple[TemporaryDirectory, Path]:
         tempdir = TemporaryDirectory()
         manifest_path = Path(tempdir.name) / filename
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
         manifest_path.write_text(content, encoding="utf-8")
         return tempdir, manifest_path
 
@@ -43,7 +44,7 @@ class TestPlatformAPIView(TestCase):
         data = response.json()
         self.assertIn("platform", data)
         self.assertIn("metadata", data)
-        self.assertEqual(data["platform"]["python_dependencies"]["source"]["path"], str(manifest_path))
+        self.assertEqual(data["platform"]["python_dependencies"]["source"]["path"], "requirements.txt")
         self.assertEqual(data["platform"]["python_dependencies"]["source"]["format"], "requirements.txt")
         self.assertEqual(
             [package["name"] for package in data["platform"]["python_dependencies"]["packages"]],
@@ -56,16 +57,25 @@ class TestPlatformAPIView(TestCase):
     def test_returns_metadata(self, mock_now, _mock_version):
         mock_now.return_value = datetime(2026, 3, 2, 12, 34, 56, tzinfo=timezone.utc)
 
-        response = self.client.get(
-            API_URL,
-            HTTP_AUTHORIZATION="Bearer test-secret",
-        )
+        tempdir, manifest_path = self._write_manifest("Django>=5.2\n")
+        self.addCleanup(tempdir.cleanup)
+
+        with self.settings(
+            BASE_DIR=tempdir.name,
+            WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+        ):
+            with patch("wagtail_unveil.platform_data.version", return_value="5.2.1"):
+                response = self.client.get(
+                    API_URL,
+                    HTTP_AUTHORIZATION="Bearer test-secret",
+                )
 
         metadata = response.json()["metadata"]
         self.assertEqual(metadata["api_version"], "v1")
         self.assertEqual(metadata["api_lifecycle"]["status"], "stable")
         self.assertEqual(metadata["generated_at"], "2026-03-02T12:34:56+00:00")
         self.assertEqual(metadata["package_version"], "9.9.9")
+        self.assertEqual(response.json()["platform"]["warnings"], [])
         self.assertNotIn("Deprecation", response)
         self.assertNotIn("Sunset", response)
 
@@ -100,18 +110,30 @@ class TestPlatformAPIView(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    def test_superuser_session_fallback_requires_debug_true(self):
+    def test_superuser_session_fallback_is_not_allowed_for_platform_endpoint(self):
         User.objects.create_superuser(username="admin", password="password")
         self.client.login(username="admin", password="password")
 
         response = self.client.get(API_URL)
 
-        self.assertEqual(response.status_code, 200)
-
-        with self.settings(DEBUG=False):
-            response = self.client.get(API_URL)
-
         self.assertEqual(response.status_code, 403)
+
+    def test_response_returns_manifest_basename_only(self):
+        tempdir, manifest_path = self._write_manifest("Django>=5.2\n", filename="requirements/base.txt")
+        self.addCleanup(tempdir.cleanup)
+
+        with self.settings(
+            BASE_DIR=tempdir.name,
+            WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+        ):
+            with patch("wagtail_unveil.platform_data.version", return_value="5.2.1"):
+                response = self.client.get(
+                    API_URL,
+                    HTTP_AUTHORIZATION="Bearer test-secret",
+                )
+
+        self.assertEqual(response.json()["platform"]["python_dependencies"]["source"]["path"], "base.txt")
+        self.assertNotIn(str(manifest_path), response.content.decode())
 
     def test_returns_warning_when_no_manifest_is_configured(self):
         with self.settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=""):

--- a/tests/views/test_platform_api.py
+++ b/tests/views/test_platform_api.py
@@ -51,6 +51,9 @@ class TestPlatformAPIView(TestCase):
             ["Django", "wagtail"],
         )
         self.assertEqual(data["platform"]["warnings"], [])
+        self.assertEqual(response["Cache-Control"], "private, no-store")
+        self.assertIn("Authorization", response["Vary"])
+        self.assertIn("Cookie", response["Vary"])
 
     @patch("wagtail_unveil.views._get_package_version", return_value="9.9.9")
     @patch("wagtail_unveil.views.timezone.now")

--- a/tests/views/test_platform_api.py
+++ b/tests/views/test_platform_api.py
@@ -1,0 +1,146 @@
+from dataclasses import replace
+from datetime import date, datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+
+from wagtail_unveil.api_contract import get_api_contract
+
+V1_CONTRACT = get_api_contract("v1")
+API_URL = f"/unveil/{V1_CONTRACT.platform_url_path}"
+
+
+@override_settings(DEBUG=True)
+@patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"})
+class TestPlatformAPIView(TestCase):
+    def _write_manifest(self, content: str, filename: str = "requirements.txt") -> tuple[TemporaryDirectory, Path]:
+        tempdir = TemporaryDirectory()
+        manifest_path = Path(tempdir.name) / filename
+        manifest_path.write_text(content, encoding="utf-8")
+        return tempdir, manifest_path
+
+    def test_returns_platform_payload(self):
+        tempdir, manifest_path = self._write_manifest("Django>=5.2\nwagtail==7.0\n")
+        self.addCleanup(tempdir.cleanup)
+
+        with self.settings(
+            BASE_DIR=tempdir.name,
+            WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+        ):
+            with patch(
+                "wagtail_unveil.platform_data.version",
+                side_effect=lambda name: {"Django": "5.2.1", "wagtail": "7.0.2"}[name],
+            ):
+                response = self.client.get(
+                    API_URL,
+                    HTTP_AUTHORIZATION="Bearer test-secret",
+                )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("platform", data)
+        self.assertIn("metadata", data)
+        self.assertEqual(data["platform"]["python_dependencies"]["source"]["path"], str(manifest_path))
+        self.assertEqual(data["platform"]["python_dependencies"]["source"]["format"], "requirements.txt")
+        self.assertEqual(
+            [package["name"] for package in data["platform"]["python_dependencies"]["packages"]],
+            ["Django", "wagtail"],
+        )
+        self.assertEqual(data["platform"]["warnings"], [])
+
+    @patch("wagtail_unveil.views._get_package_version", return_value="9.9.9")
+    @patch("wagtail_unveil.views.timezone.now")
+    def test_returns_metadata(self, mock_now, _mock_version):
+        mock_now.return_value = datetime(2026, 3, 2, 12, 34, 56, tzinfo=timezone.utc)
+
+        response = self.client.get(
+            API_URL,
+            HTTP_AUTHORIZATION="Bearer test-secret",
+        )
+
+        metadata = response.json()["metadata"]
+        self.assertEqual(metadata["api_version"], "v1")
+        self.assertEqual(metadata["api_lifecycle"]["status"], "stable")
+        self.assertEqual(metadata["generated_at"], "2026-03-02T12:34:56+00:00")
+        self.assertEqual(metadata["package_version"], "9.9.9")
+        self.assertNotIn("Deprecation", response)
+        self.assertNotIn("Sunset", response)
+
+    def test_requires_api_key(self):
+        response = self.client.get(API_URL)
+        self.assertEqual(response.status_code, 403)
+
+    def test_rejects_wrong_key(self):
+        response = self.client.get(
+            API_URL,
+            HTTP_AUTHORIZATION="Bearer wrong-key",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_returns_500_when_no_api_key_is_configured(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with self.settings(WAGTAIL_UNVEIL_API_KEY=""):
+                response = self.client.get(
+                    API_URL,
+                    HTTP_AUTHORIZATION="Bearer test-secret",
+                )
+
+        self.assertEqual(response.status_code, 500)
+
+    def test_uses_settings_fallback_when_env_missing(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with self.settings(WAGTAIL_UNVEIL_API_KEY="test-from-settings"):
+                response = self.client.get(
+                    API_URL,
+                    HTTP_AUTHORIZATION="Bearer test-from-settings",
+                )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_superuser_session_fallback_requires_debug_true(self):
+        User.objects.create_superuser(username="admin", password="password")
+        self.client.login(username="admin", password="password")
+
+        response = self.client.get(API_URL)
+
+        self.assertEqual(response.status_code, 200)
+
+        with self.settings(DEBUG=False):
+            response = self.client.get(API_URL)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_returns_warning_when_no_manifest_is_configured(self):
+        with self.settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=""):
+            response = self.client.get(
+                API_URL,
+                HTTP_AUTHORIZATION="Bearer test-secret",
+            )
+
+        data = response.json()
+        self.assertEqual(data["platform"]["python_dependencies"]["source"]["path"], "")
+        self.assertIsNone(data["platform"]["python_dependencies"]["source"]["format"])
+        self.assertEqual(data["platform"]["python_dependencies"]["packages"], [])
+        self.assertEqual(data["platform"]["warnings"], ["No dependency manifest is configured."])
+
+    @patch("wagtail_unveil.views.get_api_contract")
+    def test_response_sets_deprecation_headers_for_deprecated_contract(self, mock_get_api_contract):
+        deprecated_contract = replace(
+            V1_CONTRACT,
+            status="deprecated",
+            deprecated_on=date(2026, 1, 1),
+            sunset_on=date(2026, 12, 31),
+        )
+        mock_get_api_contract.return_value = deprecated_contract
+
+        response = self.client.get(
+            API_URL,
+            HTTP_AUTHORIZATION="Bearer test-secret",
+        )
+
+        self.assertEqual(response["Deprecation"], "true")
+        self.assertIn("Sunset", response)
+        self.assertEqual(response.json()["metadata"]["api_lifecycle"]["status"], "deprecated")

--- a/tests/views/test_settings_report.py
+++ b/tests/views/test_settings_report.py
@@ -52,7 +52,9 @@ class TestSettingsReportView(WagtailTestUtils, TestCase):
         self.assertContains(response, "URL Diagnostics")
         self.assertContains(response, "WAGTAIL_UNVEIL_API_KEY")
         self.assertContains(response, "WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS")
+        self.assertContains(response, "WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE")
         self.assertContains(response, "/unveil/api/v1/backend-urls/")
+        self.assertContains(response, "/unveil/api/v1/platform/")
         self.assertContains(response, "/unveil/report/frontend-urls/")
 
     @patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "full-secret-value"})

--- a/uv.lock
+++ b/uv.lock
@@ -1434,6 +1434,7 @@ source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "wagtail" },
 ]
 
@@ -1456,6 +1457,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=4.2" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "wagtail", specifier = ">=7.0" },
 ]
 

--- a/wagtail_unveil/AGENTS.md
+++ b/wagtail_unveil/AGENTS.md
@@ -53,7 +53,7 @@ Do not document or assume package management commands unless they are reintroduc
 - `WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE`
 
 `get_api_key()` checks the environment first, then Django settings fallback.
-JSON API requests also allow superuser session auth when `DEBUG=True` and the request is not attempting Bearer-token auth. When `DEBUG=False`, signed report-originated requests may also use a superuser session if `WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS=True`.
+The backend/frontend URL discovery JSON APIs also allow superuser session auth when `DEBUG=True` and the request is not attempting Bearer-token auth. When `DEBUG=False`, signed report-originated requests may also use a superuser session for those URL discovery APIs if `WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS=True`. The platform API always requires Bearer authentication.
 
 ### URL Names
 

--- a/wagtail_unveil/AGENTS.md
+++ b/wagtail_unveil/AGENTS.md
@@ -50,6 +50,7 @@ Do not document or assume package management commands unless they are reintroduc
 - `WAGTAIL_UNVEIL_SKIP_URL_PREFIXES`
 - `WAGTAIL_UNVEIL_API_KEY`
 - `WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS`
+- `WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE`
 
 `get_api_key()` checks the environment first, then Django settings fallback.
 JSON API requests also allow superuser session auth when `DEBUG=True` and the request is not attempting Bearer-token auth. When `DEBUG=False`, signed report-originated requests may also use a superuser session if `WAGTAIL_UNVEIL_ENABLE_PRODUCTION_REPORTS=True`.
@@ -60,6 +61,7 @@ The package exports one URL namespace:
 
 - `wagtail_unveil:api_v1_backend_urls`
 - `wagtail_unveil:api_v1_frontend_urls`
+- `wagtail_unveil:api_v1_platform`
 - `wagtail_unveil:report_backend_urls`
 - `wagtail_unveil:report_frontend_urls`
 - `wagtail_unveil:report_settings`

--- a/wagtail_unveil/api_contract.py
+++ b/wagtail_unveil/api_contract.py
@@ -15,8 +15,10 @@ class APIVersionContract:
     sunset_on: date | None
     backend_url_path: str
     frontend_url_path: str
+    platform_url_path: str
     backend_url_name: str
     frontend_url_name: str
+    platform_url_name: str
 
 
 def _parse_version_number(version: str) -> int:
@@ -57,12 +59,20 @@ def validate_api_version_registry(registry: dict[str, APIVersionContract]) -> No
         if contract.deprecated_on and contract.sunset_on and contract.deprecated_on > contract.sunset_on:
             raise ValueError(f"API contract {contract.version!r} has deprecated_on after sunset_on.")
 
-        for path in (contract.backend_url_path, contract.frontend_url_path):
+        for path in (
+            contract.backend_url_path,
+            contract.frontend_url_path,
+            contract.platform_url_path,
+        ):
             if path in seen_paths:
                 raise ValueError(f"Duplicate API path in registry: {path!r}")
             seen_paths.add(path)
 
-        for name in (contract.backend_url_name, contract.frontend_url_name):
+        for name in (
+            contract.backend_url_name,
+            contract.frontend_url_name,
+            contract.platform_url_name,
+        ):
             if name in seen_names:
                 raise ValueError(f"Duplicate API URL name in registry: {name!r}")
             seen_names.add(name)
@@ -82,8 +92,10 @@ API_VERSION_REGISTRY: dict[str, APIVersionContract] = {
         sunset_on=None,
         backend_url_path="api/v1/backend-urls/",
         frontend_url_path="api/v1/frontend-urls/",
+        platform_url_path="api/v1/platform/",
         backend_url_name="api_v1_backend_urls",
         frontend_url_name="api_v1_frontend_urls",
+        platform_url_name="api_v1_platform",
     ),
 }
 

--- a/wagtail_unveil/platform_data.py
+++ b/wagtail_unveil/platform_data.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import platform
+import re
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+import wagtail
+from django import get_version as get_django_version
+from django.conf import settings
+
+from wagtail_unveil.settings import get_platform_dependency_file
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10 only
+    import tomli as tomllib
+
+
+@dataclass(frozen=True)
+class PlatformRuntime:
+    python_version: str
+    python_implementation: str
+    django_version: str
+    wagtail_version: str
+
+
+@dataclass(frozen=True)
+class PlatformDependency:
+    name: str
+    specifier: str
+    installed_version: str
+    is_installed: bool
+    source_kind: str
+    source_name: str | None
+
+
+@dataclass(frozen=True)
+class PlatformDependencySource:
+    path: str
+    format: str | None
+
+
+@dataclass(frozen=True)
+class PlatformSnapshot:
+    runtime: PlatformRuntime
+    dependency_source: PlatformDependencySource
+    python_dependencies: list[PlatformDependency]
+    warnings: list[str]
+
+
+def get_platform_snapshot() -> PlatformSnapshot:
+    """Return runtime and dependency inventory for the current site."""
+    runtime = PlatformRuntime(
+        python_version=platform.python_version(),
+        python_implementation=platform.python_implementation(),
+        django_version=get_django_version(),
+        wagtail_version=wagtail.__version__,
+    )
+
+    configured_path = get_platform_dependency_file()
+    if not configured_path:
+        return PlatformSnapshot(
+            runtime=runtime,
+            dependency_source=PlatformDependencySource(path="", format=None),
+            python_dependencies=[],
+            warnings=["No dependency manifest is configured."],
+        )
+
+    manifest_path = _resolve_dependency_path(configured_path)
+    if not manifest_path.exists():
+        return PlatformSnapshot(
+            runtime=runtime,
+            dependency_source=PlatformDependencySource(path=str(manifest_path), format=None),
+            python_dependencies=[],
+            warnings=[f"Dependency manifest does not exist: {manifest_path}"],
+        )
+
+    dependency_format = _guess_dependency_format_from_name(manifest_path)
+
+    try:
+        dependency_format = _detect_dependency_format(manifest_path)
+        if dependency_format == "unknown":
+            return PlatformSnapshot(
+                runtime=runtime,
+                dependency_source=PlatformDependencySource(path=str(manifest_path), format="unknown"),
+                python_dependencies=[],
+                warnings=[f"Unsupported dependency manifest format: {manifest_path.name}"],
+            )
+
+        if dependency_format in {"pyproject.toml", "poetry-pyproject"}:
+            dependencies, warnings = _parse_pyproject_dependencies(manifest_path)
+        else:
+            dependencies, warnings = _parse_requirements_file(manifest_path)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        return PlatformSnapshot(
+            runtime=runtime,
+            dependency_source=PlatformDependencySource(path=str(manifest_path), format=dependency_format),
+            python_dependencies=[],
+            warnings=[f"Could not read dependency manifest {manifest_path}: {error}"],
+        )
+
+    dependencies = sorted(
+        dependencies,
+        key=lambda dependency: (
+            dependency.name.lower(),
+            dependency.source_kind,
+            dependency.source_name or "",
+            dependency.specifier,
+        ),
+    )
+    return PlatformSnapshot(
+        runtime=runtime,
+        dependency_source=PlatformDependencySource(path=str(manifest_path), format=dependency_format),
+        python_dependencies=dependencies,
+        warnings=warnings,
+    )
+
+
+def _resolve_dependency_path(configured_path: str) -> Path:
+    path = Path(configured_path)
+    if path.is_absolute():
+        return path
+    base_dir = getattr(settings, "BASE_DIR", Path.cwd())
+    return Path(base_dir) / path
+
+
+def _detect_dependency_format(path: Path) -> str:
+    if path.name == "pyproject.toml":
+        return _detect_pyproject_format(path)
+    return _guess_dependency_format_from_name(path)
+
+
+def _guess_dependency_format_from_name(path: Path) -> str | None:
+    if path.name == "pyproject.toml":
+        return "pyproject.toml"
+    if path.suffix in {".txt", ".in", ".pip"} or "requirements" in path.name.lower():
+        return "requirements.txt"
+    return "unknown"
+
+
+def _detect_pyproject_format(path: Path) -> str:
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    tool_data = data.get("tool", {})
+    poetry_data = tool_data.get("poetry", {})
+    if poetry_data.get("dependencies") or poetry_data.get("group") or poetry_data.get("extras"):
+        return "poetry-pyproject"
+    return "pyproject.toml"
+
+
+def _parse_pyproject_dependencies(path: Path) -> tuple[list[PlatformDependency], list[str]]:
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    dependencies: list[PlatformDependency] = []
+    warnings: list[str] = []
+
+    project_data = data.get("project", {})
+    dependencies.extend(
+        _build_string_dependencies(
+            project_data.get("dependencies", []),
+            source_kind="runtime",
+            source_name=None,
+        ),
+    )
+
+    optional_dependencies = project_data.get("optional-dependencies", {})
+    if isinstance(optional_dependencies, dict):
+        for extra_name, entries in optional_dependencies.items():
+            dependencies.extend(
+                _build_string_dependencies(
+                    entries,
+                    source_kind="optional",
+                    source_name=str(extra_name),
+                ),
+            )
+
+    dependency_groups = data.get("dependency-groups", {})
+    if isinstance(dependency_groups, dict):
+        for group_name, entries in dependency_groups.items():
+            flattened_entries, group_warnings = _flatten_dependency_group_entries(
+                dependency_groups,
+                group_name=str(group_name),
+                entries=entries,
+            )
+            dependencies.extend(
+                _build_string_dependencies(
+                    flattened_entries,
+                    source_kind="group",
+                    source_name=str(group_name),
+                ),
+            )
+            warnings.extend(group_warnings)
+
+    poetry_data = data.get("tool", {}).get("poetry", {})
+    poetry_dependencies = poetry_data.get("dependencies", {})
+    if isinstance(poetry_dependencies, dict):
+        dependencies.extend(_build_poetry_runtime_dependencies(poetry_dependencies))
+
+        extras = poetry_data.get("extras", {})
+        if isinstance(extras, dict):
+            dependencies.extend(_build_poetry_extra_dependencies(poetry_dependencies, extras, warnings))
+
+    poetry_groups = poetry_data.get("group", {})
+    if isinstance(poetry_groups, dict):
+        dependencies.extend(_build_poetry_group_dependencies(poetry_groups))
+
+    return dependencies, warnings
+
+
+def _parse_requirements_file(path: Path) -> tuple[list[PlatformDependency], list[str]]:
+    dependencies: list[PlatformDependency] = []
+    warnings: list[str] = []
+
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+
+        if line.startswith("-"):
+            warnings.append(f"Skipped unsupported requirements directive on line {line_number}.")
+            continue
+
+        dependency = _build_dependency_from_requirement(
+            line,
+            source_kind="runtime",
+            source_name=None,
+        )
+        if dependency is None:
+            warnings.append(f"Skipped unparseable requirement on line {line_number}.")
+            continue
+
+        dependencies.append(dependency)
+
+    return dependencies, warnings
+
+
+def _flatten_dependency_group_entries(
+    all_groups: dict,
+    *,
+    group_name: str,
+    entries,
+    seen: set[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    if seen is None:
+        seen = set()
+
+    if group_name in seen:
+        return [], [f"Skipped recursive dependency group reference for {group_name!r}."]
+
+    seen = seen | {group_name}
+    flattened_entries: list[str] = []
+    warnings: list[str] = []
+
+    if not isinstance(entries, list):
+        return [], [f"Skipped unsupported dependency group definition for {group_name!r}."]
+
+    for entry in entries:
+        if isinstance(entry, str):
+            flattened_entries.append(entry)
+            continue
+
+        if isinstance(entry, dict) and isinstance(entry.get("include-group"), str):
+            included_group_name = entry["include-group"]
+            nested_entries, nested_warnings = _flatten_dependency_group_entries(
+                all_groups,
+                group_name=included_group_name,
+                entries=all_groups.get(included_group_name, []),
+                seen=seen,
+            )
+            flattened_entries.extend(nested_entries)
+            warnings.extend(nested_warnings)
+            continue
+
+        warnings.append(f"Skipped unsupported dependency group entry in {group_name!r}.")
+
+    return flattened_entries, warnings
+
+
+def _build_string_dependencies(entries, *, source_kind: str, source_name: str | None) -> list[PlatformDependency]:
+    if not isinstance(entries, list):
+        return []
+
+    dependencies: list[PlatformDependency] = []
+    for entry in entries:
+        if not isinstance(entry, str):
+            continue
+        dependency = _build_dependency_from_requirement(entry, source_kind=source_kind, source_name=source_name)
+        if dependency is not None:
+            dependencies.append(dependency)
+
+    return dependencies
+
+
+def _build_poetry_runtime_dependencies(poetry_dependencies: dict) -> list[PlatformDependency]:
+    dependencies: list[PlatformDependency] = []
+    for dependency_name, definition in poetry_dependencies.items():
+        if dependency_name == "python":
+            continue
+        if _is_poetry_optional_dependency(definition):
+            continue
+
+        dependency = _build_poetry_dependency(
+            dependency_name=str(dependency_name),
+            definition=definition,
+            source_kind="runtime",
+            source_name=None,
+        )
+        if dependency is not None:
+            dependencies.append(dependency)
+
+    return dependencies
+
+
+def _build_poetry_extra_dependencies(
+    poetry_dependencies: dict,
+    extras: dict,
+    warnings: list[str],
+) -> list[PlatformDependency]:
+    dependencies: list[PlatformDependency] = []
+    for extra_name, extra_entries in extras.items():
+        if not isinstance(extra_entries, list):
+            continue
+
+        for extra_dependency_name in extra_entries:
+            dependency_name = str(extra_dependency_name)
+            definition = poetry_dependencies.get(dependency_name)
+            if definition is None:
+                warnings.append(f"Poetry extra {extra_name!r} references unknown dependency {dependency_name!r}.")
+                continue
+
+            dependency = _build_poetry_dependency(
+                dependency_name=dependency_name,
+                definition=definition,
+                source_kind="optional",
+                source_name=str(extra_name),
+            )
+            if dependency is not None:
+                dependencies.append(dependency)
+
+    return dependencies
+
+
+def _build_poetry_group_dependencies(poetry_groups: dict) -> list[PlatformDependency]:
+    dependencies: list[PlatformDependency] = []
+    for group_name, group_definition in poetry_groups.items():
+        if not isinstance(group_definition, dict):
+            continue
+
+        group_dependencies = group_definition.get("dependencies", {})
+        if not isinstance(group_dependencies, dict):
+            continue
+
+        for dependency_name, definition in group_dependencies.items():
+            if dependency_name == "python":
+                continue
+
+            dependency = _build_poetry_dependency(
+                dependency_name=str(dependency_name),
+                definition=definition,
+                source_kind="group",
+                source_name=str(group_name),
+            )
+            if dependency is not None:
+                dependencies.append(dependency)
+
+    return dependencies
+
+
+def _is_poetry_optional_dependency(definition) -> bool:
+    return isinstance(definition, dict) and bool(definition.get("optional"))
+
+
+def _build_poetry_dependency(
+    *,
+    dependency_name: str,
+    definition,
+    source_kind: str,
+    source_name: str | None,
+) -> PlatformDependency | None:
+    specifier = _poetry_dependency_specifier(definition)
+    return _build_dependency(
+        name=dependency_name,
+        specifier=specifier,
+        source_kind=source_kind,
+        source_name=source_name,
+    )
+
+
+def _poetry_dependency_specifier(definition) -> str:
+    if isinstance(definition, str):
+        return definition
+
+    if isinstance(definition, dict):
+        version_specifier = definition.get("version")
+        if isinstance(version_specifier, str):
+            return version_specifier
+
+        detail_parts = []
+        for key in ("git", "path", "url", "file", "rev", "branch", "tag"):
+            value = definition.get(key)
+            if isinstance(value, str):
+                detail_parts.append(f"{key}={value}")
+        if detail_parts:
+            return ", ".join(detail_parts)
+
+    return ""
+
+
+def _build_dependency_from_requirement(
+    requirement: str,
+    *,
+    source_kind: str,
+    source_name: str | None,
+) -> PlatformDependency | None:
+    parsed_requirement = _parse_requirement(requirement)
+    if parsed_requirement is None:
+        return None
+
+    name, specifier = parsed_requirement
+    return _build_dependency(
+        name=name,
+        specifier=specifier,
+        source_kind=source_kind,
+        source_name=source_name,
+    )
+
+
+def _build_dependency(*, name: str, specifier: str, source_kind: str, source_name: str | None) -> PlatformDependency:
+    installed_version = _get_installed_version(name)
+    return PlatformDependency(
+        name=name,
+        specifier=specifier,
+        installed_version=installed_version or "",
+        is_installed=installed_version is not None,
+        source_kind=source_kind,
+        source_name=source_name,
+    )
+
+
+def _get_installed_version(package_name: str) -> str | None:
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return None
+
+
+def _parse_requirement(requirement: str) -> tuple[str, str] | None:
+    match = re.match(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)", requirement)
+    if not match:
+        return None
+
+    name = match.group(1)
+    specifier = requirement[match.end() :].strip()
+    return name, specifier

--- a/wagtail_unveil/platform_data.py
+++ b/wagtail_unveil/platform_data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import platform
 import re
 from dataclasses import dataclass
@@ -16,6 +17,17 @@ try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10 only
     import tomli as tomllib
+
+
+logger = logging.getLogger(__name__)
+
+_DEPENDENCY_MANIFEST_NOT_CONFIGURED_WARNING = "No dependency manifest is configured."
+_DEPENDENCY_MANIFEST_INACCESSIBLE_WARNING = "Dependency manifest is missing or inaccessible."
+_DEPENDENCY_MANIFEST_PARSE_WARNING = "Dependency manifest could not be parsed."
+_DEPENDENCY_MANIFEST_UNSUPPORTED_WARNING = "Dependency manifest format is unsupported."
+_DEPENDENCY_MANIFEST_OUTSIDE_BASE_DIR_WARNING = (
+    "Dependency manifest must stay within BASE_DIR when configured relatively."
+)
 
 
 @dataclass(frozen=True)
@@ -65,40 +77,64 @@ def get_platform_snapshot() -> PlatformSnapshot:
             runtime=runtime,
             dependency_source=PlatformDependencySource(path="", format=None),
             python_dependencies=[],
-            warnings=["No dependency manifest is configured."],
+            warnings=[_DEPENDENCY_MANIFEST_NOT_CONFIGURED_WARNING],
         )
-
-    manifest_path = _resolve_dependency_path(configured_path)
-    if not manifest_path.exists():
-        return PlatformSnapshot(
-            runtime=runtime,
-            dependency_source=PlatformDependencySource(path=str(manifest_path), format=None),
-            python_dependencies=[],
-            warnings=[f"Dependency manifest does not exist: {manifest_path}"],
-        )
-
-    dependency_format = _guess_dependency_format_from_name(manifest_path)
 
     try:
-        dependency_format = _detect_dependency_format(manifest_path)
+        manifest_path = _resolve_dependency_path(configured_path)
+    except ValueError:
+        logger.warning(
+            "Rejected relative dependency manifest path %r because it resolved outside BASE_DIR.",
+            configured_path,
+        )
+        return PlatformSnapshot(
+            runtime=runtime,
+            dependency_source=PlatformDependencySource(path="", format=None),
+            python_dependencies=[],
+            warnings=[_DEPENDENCY_MANIFEST_OUTSIDE_BASE_DIR_WARNING],
+        )
+
+    source_path = manifest_path.name
+    if not manifest_path.exists():
+        logger.warning("Dependency manifest is missing or inaccessible: %s", manifest_path)
+        return PlatformSnapshot(
+            runtime=runtime,
+            dependency_source=PlatformDependencySource(path=source_path, format=None),
+            python_dependencies=[],
+            warnings=[_DEPENDENCY_MANIFEST_INACCESSIBLE_WARNING],
+        )
+
+    manifest_text = None
+    dependency_format = _guess_dependency_format_from_name(manifest_path)
+    try:
+        manifest_text = manifest_path.read_text(encoding="utf-8")
+        # Keep the fallback guess above so the except path still has a stable format hint.
+        dependency_format = _detect_dependency_format(manifest_path, manifest_text)
         if dependency_format == "unknown":
+            logger.warning("Dependency manifest format is unsupported for %s", manifest_path)
             return PlatformSnapshot(
                 runtime=runtime,
-                dependency_source=PlatformDependencySource(path=str(manifest_path), format="unknown"),
+                dependency_source=PlatformDependencySource(path=source_path, format="unknown"),
                 python_dependencies=[],
-                warnings=[f"Unsupported dependency manifest format: {manifest_path.name}"],
+                warnings=[_DEPENDENCY_MANIFEST_UNSUPPORTED_WARNING],
             )
 
         if dependency_format in {"pyproject.toml", "poetry-pyproject"}:
-            dependencies, warnings = _parse_pyproject_dependencies(manifest_path)
+            dependencies, warnings = _parse_pyproject_dependencies(manifest_text)
         else:
-            dependencies, warnings = _parse_requirements_file(manifest_path)
+            dependencies, warnings = _parse_requirements_file(manifest_text)
     except (OSError, tomllib.TOMLDecodeError) as error:
+        logger.warning("Failed to inspect dependency manifest %s.", manifest_path, exc_info=error)
+        warning_message = (
+            _DEPENDENCY_MANIFEST_PARSE_WARNING
+            if manifest_text is not None
+            else _DEPENDENCY_MANIFEST_INACCESSIBLE_WARNING
+        )
         return PlatformSnapshot(
             runtime=runtime,
-            dependency_source=PlatformDependencySource(path=str(manifest_path), format=dependency_format),
+            dependency_source=PlatformDependencySource(path=source_path, format=dependency_format),
             python_dependencies=[],
-            warnings=[f"Could not read dependency manifest {manifest_path}: {error}"],
+            warnings=[warning_message],
         )
 
     dependencies = sorted(
@@ -112,7 +148,7 @@ def get_platform_snapshot() -> PlatformSnapshot:
     )
     return PlatformSnapshot(
         runtime=runtime,
-        dependency_source=PlatformDependencySource(path=str(manifest_path), format=dependency_format),
+        dependency_source=PlatformDependencySource(path=source_path, format=dependency_format),
         python_dependencies=dependencies,
         warnings=warnings,
     )
@@ -121,18 +157,21 @@ def get_platform_snapshot() -> PlatformSnapshot:
 def _resolve_dependency_path(configured_path: str) -> Path:
     path = Path(configured_path)
     if path.is_absolute():
-        return path
-    base_dir = getattr(settings, "BASE_DIR", Path.cwd())
-    return Path(base_dir) / path
+        return path.resolve()
+    base_dir = Path(getattr(settings, "BASE_DIR", Path.cwd())).resolve()
+    resolved_path = (base_dir / path).resolve()
+    if not resolved_path.is_relative_to(base_dir):
+        raise ValueError("Relative dependency manifest path resolves outside BASE_DIR.")
+    return resolved_path
 
 
-def _detect_dependency_format(path: Path) -> str:
+def _detect_dependency_format(path: Path, manifest_text: str) -> str:
     if path.name == "pyproject.toml":
-        return _detect_pyproject_format(path)
+        return _detect_pyproject_format(manifest_text)
     return _guess_dependency_format_from_name(path)
 
 
-def _guess_dependency_format_from_name(path: Path) -> str | None:
+def _guess_dependency_format_from_name(path: Path) -> str:
     if path.name == "pyproject.toml":
         return "pyproject.toml"
     if path.suffix in {".txt", ".in", ".pip"} or "requirements" in path.name.lower():
@@ -140,8 +179,8 @@ def _guess_dependency_format_from_name(path: Path) -> str | None:
     return "unknown"
 
 
-def _detect_pyproject_format(path: Path) -> str:
-    data = tomllib.loads(path.read_text(encoding="utf-8"))
+def _detect_pyproject_format(manifest_text: str) -> str:
+    data = tomllib.loads(manifest_text)
     tool_data = data.get("tool", {})
     poetry_data = tool_data.get("poetry", {})
     if poetry_data.get("dependencies") or poetry_data.get("group") or poetry_data.get("extras"):
@@ -149,8 +188,8 @@ def _detect_pyproject_format(path: Path) -> str:
     return "pyproject.toml"
 
 
-def _parse_pyproject_dependencies(path: Path) -> tuple[list[PlatformDependency], list[str]]:
-    data = tomllib.loads(path.read_text(encoding="utf-8"))
+def _parse_pyproject_dependencies(manifest_text: str) -> tuple[list[PlatformDependency], list[str]]:
+    data = tomllib.loads(manifest_text)
     dependencies: list[PlatformDependency] = []
     warnings: list[str] = []
 
@@ -207,11 +246,11 @@ def _parse_pyproject_dependencies(path: Path) -> tuple[list[PlatformDependency],
     return dependencies, warnings
 
 
-def _parse_requirements_file(path: Path) -> tuple[list[PlatformDependency], list[str]]:
+def _parse_requirements_file(manifest_text: str) -> tuple[list[PlatformDependency], list[str]]:
     dependencies: list[PlatformDependency] = []
     warnings: list[str] = []
 
-    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+    for line_number, raw_line in enumerate(manifest_text.splitlines(), start=1):
         line = raw_line.split("#", 1)[0].strip()
         if not line:
             continue
@@ -250,6 +289,7 @@ def _flatten_dependency_group_entries(
     seen = seen | {group_name}
     flattened_entries: list[str] = []
     warnings: list[str] = []
+    included_groups: set[str] = set()
 
     if not isinstance(entries, list):
         return [], [f"Skipped unsupported dependency group definition for {group_name!r}."]
@@ -261,6 +301,10 @@ def _flatten_dependency_group_entries(
 
         if isinstance(entry, dict) and isinstance(entry.get("include-group"), str):
             included_group_name = entry["include-group"]
+            if included_group_name in included_groups:
+                warnings.append(f"Skipped duplicate dependency group reference for {included_group_name!r}.")
+                continue
+            included_groups.add(included_group_name)
             nested_entries, nested_warnings = _flatten_dependency_group_entries(
                 all_groups,
                 group_name=included_group_name,

--- a/wagtail_unveil/platform_data.py
+++ b/wagtail_unveil/platform_data.py
@@ -251,7 +251,7 @@ def _parse_requirements_file(manifest_text: str) -> tuple[list[PlatformDependenc
     warnings: list[str] = []
 
     for line_number, raw_line in enumerate(manifest_text.splitlines(), start=1):
-        line = raw_line.split("#", 1)[0].strip()
+        line = _strip_requirements_comment(raw_line)
         if not line:
             continue
 
@@ -305,10 +305,13 @@ def _flatten_dependency_group_entries(
                 warnings.append(f"Skipped duplicate dependency group reference for {included_group_name!r}.")
                 continue
             included_groups.add(included_group_name)
+            if included_group_name not in all_groups:
+                warnings.append(f"Skipped missing dependency group reference for {included_group_name!r}.")
+                continue
             nested_entries, nested_warnings = _flatten_dependency_group_entries(
                 all_groups,
                 group_name=included_group_name,
-                entries=all_groups.get(included_group_name, []),
+                entries=all_groups[included_group_name],
                 seen=seen,
             )
             flattened_entries.extend(nested_entries)
@@ -489,6 +492,10 @@ def _get_installed_version(package_name: str) -> str | None:
 
 
 def _parse_requirement(requirement: str) -> tuple[str, str] | None:
+    legacy_vcs_requirement = _parse_legacy_vcs_requirement(requirement)
+    if legacy_vcs_requirement is not None:
+        return legacy_vcs_requirement
+
     match = re.match(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)", requirement)
     if not match:
         return None
@@ -496,3 +503,22 @@ def _parse_requirement(requirement: str) -> tuple[str, str] | None:
     name = match.group(1)
     specifier = requirement[match.end() :].strip()
     return name, specifier
+
+
+def _strip_requirements_comment(raw_line: str) -> str:
+    stripped_line = raw_line.strip()
+    if not stripped_line or stripped_line.startswith("#"):
+        return ""
+
+    if "#egg=" in raw_line:
+        return raw_line.strip()
+
+    return raw_line.split(" #", 1)[0].strip()
+
+
+def _parse_legacy_vcs_requirement(requirement: str) -> tuple[str, str] | None:
+    egg_match = re.search(r"#egg=([A-Za-z0-9][A-Za-z0-9._-]*)", requirement)
+    if egg_match is None:
+        return None
+
+    return egg_match.group(1), requirement.strip()

--- a/wagtail_unveil/settings.py
+++ b/wagtail_unveil/settings.py
@@ -272,7 +272,7 @@ def inspect_api_key_setting():
 
     if source == "default":
         notes.append("Bearer authentication is not configured.")
-    elif source == "env" and raw_value == "":
+    elif source == "env" and _is_blank_string(raw_value):
         notes.append("Blank environment values are ignored.")
     elif not isinstance(raw_value, str):
         notes.append("Non-string values are ignored.")

--- a/wagtail_unveil/settings.py
+++ b/wagtail_unveil/settings.py
@@ -252,6 +252,18 @@ def get_api_key():
     return value.strip()
 
 
+def get_platform_dependency_file():
+    """Return WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE as a non-empty string, or '' if absent/invalid."""
+    value = os.environ.get("WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE") or getattr(
+        settings,
+        "WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE",
+        "",
+    )
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
 def inspect_api_key_setting():
     """Describe the configured and effective API key setting."""
     source, raw_value = _get_configured_source_and_raw_value("WAGTAIL_UNVEIL_API_KEY")
@@ -280,11 +292,39 @@ def inspect_api_key_setting():
     )
 
 
+def inspect_platform_dependency_file_setting():
+    """Describe the configured and effective dependency manifest setting."""
+    source, raw_value = _get_configured_source_and_raw_value("WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE")
+    effective_value = get_platform_dependency_file()
+    notes = []
+
+    if source == "default":
+        notes.append("Platform dependency inventory is unconfigured until a manifest path is provided.")
+    elif source == "env" and _is_blank_string(raw_value):
+        notes.append("Blank environment values are ignored.")
+    elif not isinstance(raw_value, str):
+        notes.append("Non-string values are ignored.")
+    else:
+        if raw_value != raw_value.strip():
+            notes.append("Leading and trailing whitespace is stripped from the effective value.")
+        if effective_value == "":
+            notes.append("Blank values leave platform dependency inventory unconfigured.")
+
+    return SettingDiagnostic(
+        name="WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE",
+        source=source,
+        raw_value=raw_value,
+        effective_value=effective_value,
+        notes=" ".join(notes) or "Value used as-is.",
+    )
+
+
 def get_setting_diagnostics():
     """Return diagnostics for all public wagtail-unveil settings."""
     return (
         inspect_api_key_setting(),
         inspect_enable_production_reports_setting(),
+        inspect_platform_dependency_file_setting(),
         inspect_pages_per_type_setting(),
         inspect_skip_url_prefixes_setting(),
     )

--- a/wagtail_unveil/settings.py
+++ b/wagtail_unveil/settings.py
@@ -246,7 +246,12 @@ def get_api_key():
 
     Invalid, non-string, or empty values return ''.
     """
-    value = os.environ.get("WAGTAIL_UNVEIL_API_KEY") or getattr(settings, "WAGTAIL_UNVEIL_API_KEY", "")
+    env_value = os.environ.get("WAGTAIL_UNVEIL_API_KEY")
+    if env_value is not None and not _is_blank_string(env_value):
+        value = env_value
+    else:
+        value = getattr(settings, "WAGTAIL_UNVEIL_API_KEY", "")
+
     if not isinstance(value, str):
         return ""
     return value.strip()
@@ -254,11 +259,15 @@ def get_api_key():
 
 def get_platform_dependency_file():
     """Return WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE as a non-empty string, or '' if absent/invalid."""
-    value = os.environ.get("WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE") or getattr(
-        settings,
-        "WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE",
-        "",
-    )
+    env_value = os.environ.get("WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE")
+    if env_value is not None and not _is_blank_string(env_value):
+        value = env_value
+    else:
+        value = getattr(
+            settings,
+            "WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE",
+            "",
+        )
     if not isinstance(value, str):
         return ""
     return value.strip()

--- a/wagtail_unveil/urls.py
+++ b/wagtail_unveil/urls.py
@@ -5,6 +5,7 @@ from wagtail_unveil.views import (
     backend_urls_report,
     build_admin_urls_json_view,
     build_frontend_urls_json_view,
+    build_platform_json_view,
     frontend_urls_report,
     settings_report,
 )
@@ -27,6 +28,13 @@ for api_version in get_supported_api_versions():
             contract.frontend_url_path,
             build_frontend_urls_json_view(api_version),
             name=contract.frontend_url_name,
+        ),
+    )
+    urlpatterns.append(
+        path(
+            contract.platform_url_path,
+            build_platform_json_view(api_version),
+            name=contract.platform_url_name,
         ),
     )
 

--- a/wagtail_unveil/views.py
+++ b/wagtail_unveil/views.py
@@ -121,7 +121,7 @@ def _has_valid_report_access_token(request):
     return compare_digest(claims.get("session_nonce", ""), session_nonce)
 
 
-def _authenticate_api_request(request):
+def _authenticate_api_request(request, *, allow_debug_superuser_session=True):
     """Validate the configured API key against the request Authorization header."""
     auth_header = request.headers.get("Authorization", "")
     parts = auth_header.split(" ", 1)
@@ -139,9 +139,9 @@ def _authenticate_api_request(request):
 
     user = getattr(request, "user", None)
     if user and user.is_authenticated and user.is_superuser:
-        if settings.DEBUG:
+        if allow_debug_superuser_session and settings.DEBUG:
             return None
-        if get_enable_production_reports() and _has_valid_report_access_token(request):
+        if allow_debug_superuser_session and get_enable_production_reports() and _has_valid_report_access_token(request):
             return None
 
     return _json_error("Invalid or missing API key", status=403)
@@ -337,9 +337,10 @@ def _build_settings_report_context():
                 "label": "Superuser session API access",
                 "value": "Enabled" if settings.DEBUG or production_reports_enabled else "Disabled",
                 "detail": (
-                    "Session-based JSON access is allowed for superusers in DEBUG "
-                    "mode, or for signed report requests when production reports "
-                    "are enabled."
+                    "Session-based JSON access is allowed for URL discovery endpoints "
+                    "for superusers in DEBUG mode, or for signed report requests when "
+                    "production reports are enabled. The platform API still requires "
+                    "Bearer authentication."
                 ),
             },
             {
@@ -504,7 +505,7 @@ def _frontend_urls_json_for_version(request, api_version):
 def _platform_json_for_version(request, api_version):
     """Return platform runtime and dependency metadata for a specific API version."""
     contract = get_api_contract(api_version)
-    auth_error = _authenticate_api_request(request)
+    auth_error = _authenticate_api_request(request, allow_debug_superuser_session=False)
     if auth_error is not None:
         return auth_error
 

--- a/wagtail_unveil/views.py
+++ b/wagtail_unveil/views.py
@@ -24,13 +24,13 @@ from wagtail_unveil.api_contract import (
 )
 from wagtail_unveil.discovery.backend import get_admin_urls
 from wagtail_unveil.discovery.frontend import get_frontend_urls
+from wagtail_unveil.platform_data import PlatformSnapshot, get_platform_snapshot
 from wagtail_unveil.settings import (
     get_api_key,
     get_enable_production_reports,
     get_setting_diagnostics,
     is_report_ui_enabled,
 )
-from wagtail_unveil.platform_data import PlatformSnapshot, get_platform_snapshot
 
 # Shared API response and authentication helpers
 
@@ -141,7 +141,11 @@ def _authenticate_api_request(request, *, allow_debug_superuser_session=True):
     if user and user.is_authenticated and user.is_superuser:
         if allow_debug_superuser_session and settings.DEBUG:
             return None
-        if allow_debug_superuser_session and get_enable_production_reports() and _has_valid_report_access_token(request):
+        if (
+            allow_debug_superuser_session
+            and get_enable_production_reports()
+            and _has_valid_report_access_token(request)
+        ):
             return None
 
     return _json_error("Invalid or missing API key", status=403)
@@ -284,7 +288,7 @@ def _build_platform_json_response(snapshot: PlatformSnapshot, *, contract: APIVe
         **_serialize_platform_snapshot(snapshot),
         "metadata": _build_platform_metadata(contract=contract),
     }
-    response = JsonResponse(data)
+    response = _apply_api_cache_headers(JsonResponse(data))
     return _apply_lifecycle_headers(response, contract)
 
 

--- a/wagtail_unveil/views.py
+++ b/wagtail_unveil/views.py
@@ -30,6 +30,7 @@ from wagtail_unveil.settings import (
     get_setting_diagnostics,
     is_report_ui_enabled,
 )
+from wagtail_unveil.platform_data import PlatformSnapshot, get_platform_snapshot
 
 # Shared API response and authentication helpers
 
@@ -211,6 +212,16 @@ def _build_urls_metadata(urls, *, applied_filter, contract: APIVersionContract):
     }
 
 
+def _build_platform_metadata(*, contract: APIVersionContract):
+    """Build metadata describing how a platform payload was produced."""
+    return {
+        "api_version": contract.version,
+        "api_lifecycle": _serialize_api_lifecycle(contract),
+        "generated_at": timezone.now().isoformat(),
+        "package_version": _get_package_version(),
+    }
+
+
 def _apply_lifecycle_headers(response: JsonResponse, contract: APIVersionContract):
     """Attach deprecation headers for deprecated API versions."""
     if contract.status != "deprecated":
@@ -232,6 +243,48 @@ def _build_urls_json_response(urls, serializer, *, applied_filter=None, contract
         "metadata": _build_urls_metadata(urls, applied_filter=applied_filter, contract=contract),
     }
     response = _apply_api_cache_headers(JsonResponse(data))
+    return _apply_lifecycle_headers(response, contract)
+
+
+def _serialize_platform_snapshot(snapshot: PlatformSnapshot):
+    """Serialize platform runtime and dependency inventory for JSON responses."""
+    return {
+        "platform": {
+            "runtime": {
+                "python_version": snapshot.runtime.python_version,
+                "python_implementation": snapshot.runtime.python_implementation,
+                "django_version": snapshot.runtime.django_version,
+                "wagtail_version": snapshot.runtime.wagtail_version,
+            },
+            "python_dependencies": {
+                "source": {
+                    "path": snapshot.dependency_source.path,
+                    "format": snapshot.dependency_source.format,
+                },
+                "packages": [
+                    {
+                        "name": dependency.name,
+                        "specifier": dependency.specifier,
+                        "installed_version": dependency.installed_version,
+                        "is_installed": dependency.is_installed,
+                        "source_kind": dependency.source_kind,
+                        "source_name": dependency.source_name,
+                    }
+                    for dependency in snapshot.python_dependencies
+                ],
+            },
+            "warnings": snapshot.warnings,
+        },
+    }
+
+
+def _build_platform_json_response(snapshot: PlatformSnapshot, *, contract: APIVersionContract):
+    """Serialize platform data and wrap it in the versioned JSON payload."""
+    data = {
+        **_serialize_platform_snapshot(snapshot),
+        "metadata": _build_platform_metadata(contract=contract),
+    }
+    response = JsonResponse(data)
     return _apply_lifecycle_headers(response, contract)
 
 
@@ -339,6 +392,11 @@ def _build_settings_report_context():
                 "detail": f"URL name: wagtail_unveil:{contract.frontend_url_name}",
             },
             {
+                "label": "Platform API",
+                "value": reverse(f"wagtail_unveil:{contract.platform_url_name}"),
+                "detail": f"URL name: wagtail_unveil:{contract.platform_url_name}",
+            },
+            {
                 "label": "Backend URLs report",
                 "value": reverse("wagtail_unveil:report_backend_urls"),
                 "detail": "URL name: wagtail_unveil:report_backend_urls",
@@ -382,6 +440,11 @@ def _get_frontend_serializer_for_version(_api_version):
     """Return frontend serializer function for a specific API version."""
     # Future API versions can customize response fields here.
     return _serialize_frontend_url
+
+
+def _get_platform_snapshot_for_version(_api_version):
+    """Return platform runtime and dependency metadata for a specific API version."""
+    return get_platform_snapshot()
 
 
 def _admin_urls_json_for_version(request, api_version):
@@ -438,6 +501,17 @@ def _frontend_urls_json_for_version(request, api_version):
     )
 
 
+def _platform_json_for_version(request, api_version):
+    """Return platform runtime and dependency metadata for a specific API version."""
+    contract = get_api_contract(api_version)
+    auth_error = _authenticate_api_request(request)
+    if auth_error is not None:
+        return auth_error
+
+    snapshot = _get_platform_snapshot_for_version(api_version)
+    return _build_platform_json_response(snapshot, contract=contract)
+
+
 # JSON view builders
 
 
@@ -461,9 +535,20 @@ def build_frontend_urls_json_view(api_version):
     return view
 
 
+def build_platform_json_view(api_version):
+    """Build a Django view callable bound to a specific platform API version."""
+
+    def view(request):
+        return _platform_json_for_version(request, api_version)
+
+    view.__name__ = f"platform_json_{api_version}"
+    return view
+
+
 # Backward-compatible callables bound to the current latest stable API version.
 admin_urls_json = build_admin_urls_json_view(get_latest_stable_api_version())
 frontend_urls_json = build_frontend_urls_json_view(get_latest_stable_api_version())
+platform_json = build_platform_json_view(get_latest_stable_api_version())
 
 
 # HTML report views


### PR DESCRIPTION
## Summary
- add versioned `/unveil/api/v1/platform/` routing and JSON response support to the API contract
- implement platform runtime and Python dependency inventory collection, including manifest parsing, installed-version lookup, and warning-based fallback behavior
- harden platform API behavior by requiring Bearer auth for `/unveil/api/v1/platform/`, applying private/no-store cache headers to successful responses, and clarifying auth semantics in contributor/user docs
- add settings, diagnostics, changelog, and agent-doc updates for `WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE`
- add coverage for contract routing, platform API auth/response behavior, settings precedence, diagnostics, and dependency manifest parsing

## Testing
- `make lint`
- `uv run python -m django test tests.platform.test_platform_data tests.views.test_platform_api tests.api.test_api_contract tests.settings.test_runtime_settings tests.settings.test_diagnostics tests.views.test_settings_report --settings=sandbox.settings`
- `uv run python -m django test tests.views.test_platform_api tests.views.test_backend_api --settings=sandbox.settings`