### PR TITLE
Prepare 0.1.0a6 release metadata

### DIFF
--- a/.github/release-0.1.0a6.md
+++ b/.github/release-0.1.0a6.md
@@ -1,0 +1,54 @@
+# wagtail-unveil 0.1.0a6
+
+Sixth public alpha release for `wagtail-unveil`.
+
+This release is still intended for early adopters and real-world testing rather than mainstream production use. Expect ongoing refinement and some breaking changes before the first stable release.
+
+## Full Change Summary
+
+- simplify the public docs IA so `README.md` stays focused on the GitHub/PyPI overview and the docs site carries the deeper guides
+- add an MkDocs + Material documentation site with Mermaid support, CI validation, and GitHub Pages deployment
+- tighten contributor workflow guidance across `make help`, contributor docs, and agent docs
+- clarify branch/PR workflow expectations for issue-linked work, new work started from `main`, and PR metadata drift
+- streamline admin and frontend discovery internals without changing their public discovery behavior
+- harden API and report access for production use with safer auth checks, private no-store responses, and explicit production-report enablement
+- exclude private Wagtail pages from frontend discovery output
+- add the authenticated `/unveil/api/v1/platform/` endpoint for runtime and dependency inventory diagnostics
+- add the `/unveil/report/platform/` HTML report and wire it into the dashboard and report navigation
+
+## Audience
+
+- developers evaluating `wagtail-unveil` on real Wagtail projects
+- teams willing to test early and share feedback on gaps, edge cases, and DX
+
+## Known expectations for this alpha
+
+- behavior and documentation may still change before a stable release
+- package interfaces should be treated as provisional
+- feedback from real projects will shape the next pre-release iterations
+
+## Since 0.1.0a5
+
+### Documentation And Workflow
+
+- the project now ships a fuller MkDocs documentation site and keeps the README focused on package overview and quickstart
+- contributor command guidance was tightened around the sandbox workflow, grouped `make help` output, and clearer ownership between contributor docs and agent docs
+- agent workflow guidance now explicitly covers branch creation from `main` and PR title/summary drift checks
+
+### Discovery And Reports
+
+- backend and frontend discovery internals were simplified by inlining trivial helpers while preserving public behavior
+- frontend discovery excludes private Wagtail pages and related private-derived example URLs
+- report runner pause and cancel behavior was tightened so long-running report sessions stop and settle more predictably
+
+### Security And Diagnostics
+
+- JSON API and HTML report access paths now use stricter production-safe controls, including masked settings diagnostics, constant-time bearer-key checks, and private no-store cache headers
+- a new platform API endpoint exposes runtime metadata and dependency inventory with warnings instead of hard failures when manifest metadata is incomplete
+- a matching platform HTML report is available in the admin UI and linked from existing diagnostics surfaces
+
+## Install
+
+```bash
+pip install wagtail-unveil==0.1.0a6
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to `wagtail-unveil` are documented in this file.
 
 ## Unreleased
 
-Changes merged to `main` since the last release.
+No unreleased changes yet.
+
+## 0.1.0a6 - 2026-04-10
+
+Sixth public alpha release.
+
+This alpha continues to target early adopters and real-world testing. Package behavior and documentation should still be treated as provisional before the first stable release.
 
 ### Highlights
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ It exposes discovery through:
 Canonical documentation hub: [wagtail-unveil documentation](https://nm-packages.github.io/wagtail-unveil/)
 
 ```bash
-pip install wagtail-unveil==0.1.0a5
+pip install wagtail-unveil==0.1.0a6
 ```
 
-> `0.1.0a5` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
+> `0.1.0a6` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
 > To track unreleased changes from GitHub instead, use:
 
 ```bash

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -91,7 +91,7 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
     "total_count": 190,
     "testable_count": 150,
     "untestable_count": 40,
-    "package_version": "0.1.0a5"
+    "package_version": "0.1.0a6"
   }
 }
 ```
@@ -171,7 +171,7 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
     "total_count": 42,
     "testable_count": 31,
     "untestable_count": 11,
-    "package_version": "0.1.0a5"
+    "package_version": "0.1.0a6"
   }
 }
 ```
@@ -256,7 +256,7 @@ curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api
       "sunset_on": null
     },
     "generated_at": "2026-04-08T12:34:56+00:00",
-    "package_version": "0.1.0a5"
+    "package_version": "0.1.0a6"
   }
 }
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,10 +9,10 @@
 ## Install the Package
 
 ```bash
-pip install wagtail-unveil==0.1.0a5
+pip install wagtail-unveil==0.1.0a6
 ```
 
-> `0.1.0a5` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
+> `0.1.0a6` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
 > To try the latest unreleased changes from GitHub instead:
 >
 > ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wagtail-unveil"
-version = "0.1.0a5"
+version = "0.1.0a6"
 description = "Discover and test all URLs in your Wagtail site — frontend and admin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/js/report_bundle_smoke.test.js
+++ b/tests/js/report_bundle_smoke.test.js
@@ -36,7 +36,7 @@ function createPlatformPayload(packages = []) {
         status: "stable",
       },
       generated_at: "2026-04-08T20:27:18.791636+00:00",
-      package_version: "0.1.0a5",
+      package_version: "0.1.0a6",
     },
   };
 }
@@ -420,7 +420,7 @@ describe("report bundle", () => {
       document.querySelector(
         "#platform-metadata-body tr:last-child td:last-child",
       ).textContent,
-    ).toBe("0.1.0a5");
+    ).toBe("0.1.0a6");
   });
 
   test("platform report renders empty states for warnings and dependencies", async () => {

--- a/uv.lock
+++ b/uv.lock
@@ -1429,7 +1429,7 @@ wheels = [
 
 [[package]]
 name = "wagtail-unveil"
-version = "0.1.0a5"
+version = "0.1.0a6"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
## Summary
- bump the package version from `0.1.0a5` to `0.1.0a6`
- cut the `0.1.0a6` changelog entry and reset `## Unreleased`
- update README, install docs, API examples, lockfile, and JS smoke tests to the new release version
- add the GitHub release notes file for `0.1.0a6`

## Testing
- `npm run test:js -- tests/js/report_bundle_smoke.test.js`
- `uv build --sdist --wheel --out-dir /tmp/wagtail-unveil-dist-check`
- `uvx twine check /tmp/wagtail-unveil-dist-check/*`