### PR TITLE
Fix platform dependency inventory for relative -r requirements includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `wagtail-unveil` are documented in this file.
 
 ## Unreleased
 
-No unreleased changes yet.
+- taught the platform dependency inventory to follow relative `-r other-file.txt` includes in requirements-style manifests, so shared base requirement files are reflected in `/unveil/api/v1/platform/`
 
 ## 0.1.0a6 - 2026-04-10
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -201,6 +201,7 @@ GET /unveil/api/v1/platform/
 **Configuration:**
 
 - Set `WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE` to a supported manifest file such as `pyproject.toml` or `requirements.txt`
+- Requirements-style manifests support relative `-r other-file.txt` includes for shared base dependency files
 - The endpoint still returns `200` when dependency metadata is unavailable, and reports the problem in `platform.warnings`
 - Unlike the URL discovery endpoints, this endpoint requires Bearer auth for normal API clients even when `DEBUG=True`
 - The HTML platform report at `/unveil/report/platform/` consumes this endpoint internally for superuser debugging, but the browser request authenticates with the signed `X-Wagtail-Unveil-Report-Access` header plus the superuser session, not the Bearer API key

--- a/docs/configuration/settings-reference.md
+++ b/docs/configuration/settings-reference.md
@@ -65,6 +65,7 @@ WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE = "pyproject.toml"
 - Relative paths are resolved from Django `BASE_DIR` and must stay within that directory
 - Absolute paths are used directly
 - Supported formats in v1 are `pyproject.toml` and requirements-style text files
+- Requirements-style manifests also support relative `-r other-file.txt` includes resolved from the file that declares them
 - If the setting is unset, unreadable, missing, or unsupported, the platform endpoint still returns runtime data and adds a warning instead of failing the whole response
 
 ## `WAGTAIL_UNVEIL_PAGES_PER_TYPE`

--- a/tests/platform/test_platform_data.py
+++ b/tests/platform/test_platform_data.py
@@ -235,6 +235,89 @@ ruff = "^0.9"
         self.assertEqual(snapshot.python_dependencies[0].installed_version, "")
         self.assertFalse(snapshot.python_dependencies[0].is_installed)
 
+    def test_requirements_file_includes_relative_base_file(self):
+        with TemporaryDirectory() as tempdir:
+            base_dir = Path(tempdir)
+            manifest_path = base_dir / "requirements" / "production.txt"
+            manifest_path.parent.mkdir()
+            manifest_path.write_text("-r base.txt\n", encoding="utf-8")
+            (manifest_path.parent / "base.txt").write_text(
+                "Django>=5.2\nwagtail==7.0\n",
+                encoding="utf-8",
+            )
+
+            with override_settings(
+                BASE_DIR=base_dir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="requirements/production.txt",
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch(
+                        "wagtail_unveil.platform_data.version",
+                        side_effect=lambda name: {"Django": "5.2.1", "wagtail": "7.0.2"}[name],
+                    ):
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual(
+            [dependency.name for dependency in snapshot.python_dependencies],
+            ["Django", "wagtail"],
+        )
+        self.assertEqual(snapshot.warnings, [])
+
+    def test_requirements_file_merges_included_and_local_dependencies(self):
+        with TemporaryDirectory() as tempdir:
+            base_dir = Path(tempdir)
+            manifest_path = base_dir / "requirements" / "production.txt"
+            manifest_path.parent.mkdir()
+            manifest_path.write_text(
+                "-r base.txt\npsycopg[binary]>=3.3.3,<3.4\nwhitenoise>=6.11.0,<7\n",
+                encoding="utf-8",
+            )
+            (manifest_path.parent / "base.txt").write_text(
+                "Django>=5.2\nwagtail==7.0\n",
+                encoding="utf-8",
+            )
+
+            versions = {
+                "Django": "5.2.1",
+                "psycopg": "3.3.4",
+                "wagtail": "7.0.2",
+                "whitenoise": "6.11.1",
+            }
+            with override_settings(
+                BASE_DIR=base_dir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="requirements/production.txt",
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch("wagtail_unveil.platform_data.version", side_effect=lambda name: versions[name]):
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual(
+            [dependency.name for dependency in snapshot.python_dependencies],
+            ["Django", "psycopg", "wagtail", "whitenoise"],
+        )
+        self.assertEqual(snapshot.warnings, [])
+
+    def test_missing_included_requirements_file_adds_warning(self):
+        with TemporaryDirectory() as tempdir:
+            base_dir = Path(tempdir)
+            manifest_path = base_dir / "requirements" / "production.txt"
+            manifest_path.parent.mkdir()
+            manifest_path.write_text(
+                "-r base.txt\nDjango>=5.2\n",
+                encoding="utf-8",
+            )
+
+            with override_settings(
+                BASE_DIR=base_dir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="requirements/production.txt",
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch("wagtail_unveil.platform_data.version", return_value="5.2.1"):
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual([dependency.name for dependency in snapshot.python_dependencies], ["Django"])
+        self.assertEqual(snapshot.warnings, ["Skipped missing included requirements file on line 1."])
+
     def test_requirements_vcs_dependency_preserves_egg_fragment_name(self):
         with TemporaryDirectory() as tempdir:
             manifest_path = Path(tempdir) / "requirements.txt"

--- a/tests/platform/test_platform_data.py
+++ b/tests/platform/test_platform_data.py
@@ -318,6 +318,28 @@ ruff = "^0.9"
         self.assertEqual([dependency.name for dependency in snapshot.python_dependencies], ["Django"])
         self.assertEqual(snapshot.warnings, ["Skipped missing included requirements file on line 1."])
 
+    def test_relative_include_outside_base_dir_adds_warning(self):
+        with TemporaryDirectory() as tempdir:
+            workspace_dir = Path(tempdir)
+            base_dir = workspace_dir / "project"
+            base_dir.mkdir()
+            secret_manifest = workspace_dir / "outside.txt"
+            secret_manifest.write_text("secret-package==1.0\n", encoding="utf-8")
+            manifest_path = base_dir / "requirements" / "production.txt"
+            manifest_path.parent.mkdir()
+            manifest_path.write_text("-r ../../outside.txt\nDjango>=5.2\n", encoding="utf-8")
+
+            with override_settings(
+                BASE_DIR=base_dir,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE="requirements/production.txt",
+            ):
+                with patch.dict("os.environ", {}, clear=True):
+                    with patch("wagtail_unveil.platform_data.version", return_value="5.2.1"):
+                        snapshot = get_platform_snapshot()
+
+        self.assertEqual([dependency.name for dependency in snapshot.python_dependencies], ["Django"])
+        self.assertEqual(snapshot.warnings, ["Skipped included requirements file outside BASE_DIR on line 1."])
+
     def test_requirements_vcs_dependency_preserves_egg_fragment_name(self):
         with TemporaryDirectory() as tempdir:
             manifest_path = Path(tempdir) / "requirements.txt"

--- a/tests/views/test_platform_api.py
+++ b/tests/views/test_platform_api.py
@@ -56,6 +56,34 @@ class TestPlatformAPIView(TestCase):
         self.assertIn("Authorization", response["Vary"])
         self.assertIn("Cookie", response["Vary"])
 
+    def test_returns_platform_payload_with_relative_requirements_include(self):
+        tempdir, manifest_path = self._write_manifest(
+            "-r base.txt\nwhitenoise>=6.11.0,<7\n",
+            filename="requirements/production.txt",
+        )
+        self.addCleanup(tempdir.cleanup)
+        (manifest_path.parent / "base.txt").write_text("Django>=5.2\n", encoding="utf-8")
+
+        versions = {
+            "Django": "5.2.1",
+            "whitenoise": "6.11.1",
+        }
+        with self.settings(
+            BASE_DIR=tempdir.name,
+            WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+        ):
+            with patch("wagtail_unveil.platform_data.version", side_effect=lambda name: versions[name]):
+                response = self.client.get(
+                    API_URL,
+                    HTTP_AUTHORIZATION="Bearer test-secret",
+                )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [package["name"] for package in response.json()["platform"]["python_dependencies"]["packages"]],
+            ["Django", "whitenoise"],
+        )
+
     @patch("wagtail_unveil.views._get_package_version", return_value="9.9.9")
     @patch("wagtail_unveil.views.timezone.now")
     def test_returns_metadata(self, mock_now, _mock_version):

--- a/wagtail_unveil/platform_data.py
+++ b/wagtail_unveil/platform_data.py
@@ -122,7 +122,7 @@ def get_platform_snapshot() -> PlatformSnapshot:
         if dependency_format in {"pyproject.toml", "poetry-pyproject"}:
             dependencies, warnings = _parse_pyproject_dependencies(manifest_text)
         else:
-            dependencies, warnings = _parse_requirements_file(manifest_text)
+            dependencies, warnings = _parse_requirements_file(manifest_path)
     except (OSError, tomllib.TOMLDecodeError) as error:
         logger.warning("Failed to inspect dependency manifest %s.", manifest_path, exc_info=error)
         warning_message = (
@@ -246,13 +246,41 @@ def _parse_pyproject_dependencies(manifest_text: str) -> tuple[list[PlatformDepe
     return dependencies, warnings
 
 
-def _parse_requirements_file(manifest_text: str) -> tuple[list[PlatformDependency], list[str]]:
+def _parse_requirements_file(
+    manifest_path: Path,
+    *,
+    seen_paths: set[Path] | None = None,
+) -> tuple[list[PlatformDependency], list[str]]:
     dependencies: list[PlatformDependency] = []
     warnings: list[str] = []
+    resolved_manifest_path = manifest_path.resolve()
+
+    if seen_paths is None:
+        seen_paths = set()
+    if resolved_manifest_path in seen_paths:
+        return [], ["Skipped recursive requirements include."]
+
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+    seen_paths = seen_paths | {resolved_manifest_path}
 
     for line_number, raw_line in enumerate(manifest_text.splitlines(), start=1):
         line = _strip_requirements_comment(raw_line)
         if not line:
+            continue
+
+        include_path = _parse_requirements_include(line)
+        if include_path is not None:
+            nested_manifest_path = manifest_path.parent / include_path
+            try:
+                nested_dependencies, nested_warnings = _parse_requirements_file(
+                    nested_manifest_path,
+                    seen_paths=seen_paths,
+                )
+            except OSError:
+                warnings.append(f"Skipped missing included requirements file on line {line_number}.")
+                continue
+            dependencies.extend(nested_dependencies)
+            warnings.extend(nested_warnings)
             continue
 
         if line.startswith("-"):
@@ -271,6 +299,22 @@ def _parse_requirements_file(manifest_text: str) -> tuple[list[PlatformDependenc
         dependencies.append(dependency)
 
     return dependencies, warnings
+
+
+def _parse_requirements_include(requirement_line: str) -> str | None:
+    match = re.match(r"^-r\s+(.+)$", requirement_line)
+    if match is None:
+        return None
+
+    include_path = match.group(1).strip()
+    if not include_path:
+        return None
+
+    include_candidate = Path(include_path)
+    if include_candidate.is_absolute():
+        return None
+
+    return include_path
 
 
 def _flatten_dependency_group_entries(

--- a/wagtail_unveil/platform_data.py
+++ b/wagtail_unveil/platform_data.py
@@ -95,6 +95,7 @@ def get_platform_snapshot() -> PlatformSnapshot:
         )
 
     source_path = manifest_path.name
+    include_base_dir = _get_relative_dependency_base_dir(configured_path)
     if not manifest_path.exists():
         logger.warning("Dependency manifest is missing or inaccessible: %s", manifest_path)
         return PlatformSnapshot(
@@ -122,7 +123,10 @@ def get_platform_snapshot() -> PlatformSnapshot:
         if dependency_format in {"pyproject.toml", "poetry-pyproject"}:
             dependencies, warnings = _parse_pyproject_dependencies(manifest_text)
         else:
-            dependencies, warnings = _parse_requirements_file(manifest_path)
+            dependencies, warnings = _parse_requirements_file(
+                manifest_path,
+                include_base_dir=include_base_dir,
+            )
     except (OSError, tomllib.TOMLDecodeError) as error:
         logger.warning("Failed to inspect dependency manifest %s.", manifest_path, exc_info=error)
         warning_message = (
@@ -163,6 +167,13 @@ def _resolve_dependency_path(configured_path: str) -> Path:
     if not resolved_path.is_relative_to(base_dir):
         raise ValueError("Relative dependency manifest path resolves outside BASE_DIR.")
     return resolved_path
+
+
+def _get_relative_dependency_base_dir(configured_path: str) -> Path | None:
+    path = Path(configured_path)
+    if path.is_absolute():
+        return None
+    return Path(getattr(settings, "BASE_DIR", Path.cwd())).resolve()
 
 
 def _detect_dependency_format(path: Path, manifest_text: str) -> str:
@@ -249,6 +260,7 @@ def _parse_pyproject_dependencies(manifest_text: str) -> tuple[list[PlatformDepe
 def _parse_requirements_file(
     manifest_path: Path,
     *,
+    include_base_dir: Path | None = None,
     seen_paths: set[Path] | None = None,
 ) -> tuple[list[PlatformDependency], list[str]]:
     dependencies: list[PlatformDependency] = []
@@ -270,10 +282,19 @@ def _parse_requirements_file(
 
         include_path = _parse_requirements_include(line)
         if include_path is not None:
-            nested_manifest_path = manifest_path.parent / include_path
+            try:
+                nested_manifest_path = _resolve_included_requirements_path(
+                    manifest_path,
+                    include_path,
+                    include_base_dir=include_base_dir,
+                )
+            except ValueError:
+                warnings.append(f"Skipped included requirements file outside BASE_DIR on line {line_number}.")
+                continue
             try:
                 nested_dependencies, nested_warnings = _parse_requirements_file(
                     nested_manifest_path,
+                    include_base_dir=include_base_dir,
                     seen_paths=seen_paths,
                 )
             except OSError:
@@ -299,6 +320,18 @@ def _parse_requirements_file(
         dependencies.append(dependency)
 
     return dependencies, warnings
+
+
+def _resolve_included_requirements_path(
+    manifest_path: Path,
+    include_path: str,
+    *,
+    include_base_dir: Path | None,
+) -> Path:
+    resolved_path = (manifest_path.parent / include_path).resolve()
+    if include_base_dir is not None and not resolved_path.is_relative_to(include_base_dir):
+        raise ValueError("Included requirements path resolves outside BASE_DIR.")
+    return resolved_path
 
 
 def _parse_requirements_include(requirement_line: str) -> str | None:


### PR DESCRIPTION
## Summary
- parse requirements manifests from disk so relative `-r other-file.txt` includes can be followed
- merge packages from included requirements files into the platform dependency inventory while preserving existing warning behavior for unsupported directives
- document the new requirements include support and add an unreleased changelog entry

Closes #100.

## Testing
- `DJANGO_SETTINGS_MODULE=sandbox.settings uv run django-admin test tests.platform.test_platform_data tests.views.test_platform_api`
- `make lint`
