### PR TITLE
Add agent workflow guidance for refactoring and self-review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,12 @@ Required startup sequence for issue work:
 3. Fetch remote refs and switch to the linked branch locally before editing files.
 4. If no linked branch exists, create and link a branch for the issue, then switch to that branch before making changes.
 
+Required PR linkage for issue-scoped work:
+
+1. When opening a new PR for work that came from a GitHub issue, mention the issue in the PR body.
+2. Prefer a closing keyword such as `Closes #123` when the PR is intended to fully resolve the issue; otherwise include a plain issue reference so the relationship is still visible.
+3. Verify that the issue reference is present before finalizing the PR creation flow.
+
 Required startup sequence for new scoped work begun outside an existing issue branch:
 
 1. Check the current local branch before making changes.
@@ -46,9 +52,19 @@ Required PR-metadata check when working on an existing branch:
 3. Offer a short set of concrete replacement PR title suggestions for the user to choose from.
 4. Treat the PR summary/body as needing the same drift check and update discussion, not just the title.
 
+Required agent self-review before handoff:
+
+1. After completing a code change, review the patch before final handoff or PR creation.
+2. Use the existing repo guidance as the review baseline, including `CONVENTIONS.md`, relevant nested `AGENTS.md` files, contributor validation workflow, and any task-specific architecture docs.
+3. Check for maintainability, unnecessary complexity, duplicated logic, duplicated or overly fragmented tests that could be sensibly combined or refactored, missing or weak tests, documentation drift, scope creep, and obvious security or safety regressions that follow from the touched code.
+4. Run the relevant validation steps already required by repo guidance when feasible, and incorporate the results into that review.
+5. If the review finds worthwhile follow-up improvements that are not clearly required to finish the task, call them out explicitly and get approval before broadening the patch.
+6. If the review finds a required fix for correctness, safety, or repo-policy compliance, address it before considering the work complete.
+
 Safety rule: do not start implementation for issue-scoped work on `main` when the issue is expected to have its own branch. Do not start newly scoped work on `main` without first checking whether the user wants a branch created and proposing a suitable branch title. When working on a branch with an open PR, do not ignore title/summary drift if the branch scope has materially changed.
 
 For contributor commands, validation loops, and release-adjacent workflow, use `docs/contributing/development.md` as the canonical reference. For coding, testing, and documentation conventions, use `CONVENTIONS.md`.
+When changing code, treat local simplification of touched duplication or unnecessary indirection as part of completing the work, not optional polish; keep the canonical thresholds and scope limits in `CONVENTIONS.md`.
 
 ## Architecture Summary
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -11,6 +11,27 @@
 - **Models:** Use `BigAutoField` as default auto field, descriptive `class Meta` with `verbose_name`/`verbose_name_plural`
 - **URLs:** Use `path()` not `re_path()`, use `app_name` namespacing
 
+## Refactoring While Changing Code
+
+- **Refactor nearby touched code:** When a feature, bug fix, or review-driven change touches an area that has obvious local duplication, unnecessary indirection, or newly exposed complexity, simplify it in the same patch when the refactor is behavior-preserving and low risk.
+- **Prefer simpler extensions to layered helpers:** When extending existing logic, prefer the clearest implementation that fits the current need rather than adding tiny one-use helpers, parallel branches, or extra abstraction layers that make the touched flow harder to follow.
+- **Do not widen scope for speculative cleanup:** Keep opportunistic refactors local to the code already being changed. Do not turn a scoped fix into broader cleanup, module reshuffling, or unrelated architectural work unless that larger change is required for correctness, testability, or clarity of the touched behavior.
+- **Remove duplication introduced by the current change:** If the new work creates obvious repeated setup, repeated branching, or repeated parsing/resolution logic, clean that duplication up before finalizing the patch when doing so does not materially increase risk.
+- **Call out deferred refactors:** If a useful refactor is noticed but intentionally left out to preserve scope, mention that explicitly in the final handoff or PR discussion instead of silently leaving the opportunity undocumented.
+
+Good fit examples:
+
+- extracting repeated test setup into a small helper when several new tests need the same manifest or page fixture arrangement
+- combining or refactoring tests when new coverage introduces obvious duplicated setup, assertions, or scenario scaffolding without making the resulting test intent harder to read
+- collapsing a tiny one-use helper or branch added during the change when it adds indirection without improving readability
+- simplifying touched parsing, discovery, or resolution logic when the new requirement reveals duplicated or over-factored control flow
+
+Not a good fit examples:
+
+- reorganizing multiple modules during a narrow bug fix when the existing file layout is not blocking the change
+- renaming broad internal APIs or moving symbols across subsystems purely for taste while implementing a scoped behavior change
+- turning a local readability cleanup into a wider refactor that changes unrelated code paths or expands test surface without a concrete need
+
 ## Testing Conventions
 
 - **Root-level `tests/` package** split by feature area (not inside the distributable package)


### PR DESCRIPTION
## Summary
- add agent workflow guidance in `AGENTS.md` for linking issue-scoped PRs, reviewing completed changes before handoff, and surfacing optional follow-up improvements for approval
- add canonical refactoring guidance in `CONVENTIONS.md`, including when to simplify touched code and when to avoid broad cleanup
- document support for relative `-r other-file.txt` includes in platform dependency manifests and cover the behavior with platform snapshot and API tests

## Testing
- Not run (not requested)