### PR TITLE
Prepare 0.1.0a7 release

### DIFF
--- a/.github/release-0.1.0a7.md
+++ b/.github/release-0.1.0a7.md
@@ -1,0 +1,40 @@
+# wagtail-unveil 0.1.0a7
+
+Seventh public alpha release for `wagtail-unveil`.
+
+This release is still intended for early adopters and real-world testing rather than mainstream production use. Expect ongoing refinement and some breaking changes before the first stable release.
+
+## Full Change Summary
+
+- add inline Markdown export and copy support to the platform HTML report so the current runtime and dependency inventory can be shared from the admin UI
+- teach the platform dependency inventory to follow relative `-r other-file.txt` includes in requirements-style manifests
+- include shared or base requirements files in `/unveil/api/v1/platform/` output when a discovered manifest references them via `-r`
+
+## Audience
+
+- developers evaluating `wagtail-unveil` on real Wagtail projects
+- teams willing to test early and share feedback on gaps, edge cases, and DX
+
+## Known expectations for this alpha
+
+- behavior and documentation may still change before a stable release
+- package interfaces should be treated as provisional
+- feedback from real projects will shape the next pre-release iterations
+
+## Since 0.1.0a6
+
+### Platform Report
+
+- the platform HTML report can now render a raw Markdown summary of the current runtime and dependency inventory
+- the generated Markdown can be copied directly from the report UI, and it includes latest-version comparison data when those browser-side PyPI lookups are available
+
+### Platform Dependency Inventory
+
+- requirements-style manifests can now pull in relative include files through `-r other-file.txt`
+- dependency inventory output now reflects shared/base requirement files referenced from the primary manifest, which makes `/unveil/api/v1/platform/` more representative of real project dependency layouts
+
+## Install
+
+```bash
+pip install wagtail-unveil==0.1.0a7
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Every pull request must add or update an entry under `## Unreleased` in this fil
 ## Unreleased
 
 - clarified repo guidance so every pull request must update `CHANGELOG.md` under `## Unreleased`, and added that check to the agent self-review workflow
+
+## 0.1.0a7 - 2026-04-12
+
+Seventh public alpha release.
+
+This alpha continues to target early adopters and real-world testing. Package behavior and documentation should still be treated as provisional before the first stable release.
+
+### Highlights
+
+- added a Markdown export and copy action to the platform HTML report so the current runtime and dependency inventory can be shared without leaving the admin UI
 - taught the platform dependency inventory to follow relative `-r other-file.txt` includes in requirements-style manifests, so shared base requirement files are reflected in `/unveil/api/v1/platform/`
 
 ## 0.1.0a6 - 2026-04-10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wagtail-unveil"
-version = "0.1.0a6"
+version = "0.1.0a7"
 description = "Discover and test all URLs in your Wagtail site — frontend and admin."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/views/test_platform_api.py
+++ b/tests/views/test_platform_api.py
@@ -28,18 +28,19 @@ class TestPlatformAPIView(TestCase):
         tempdir, manifest_path = self._write_manifest("Django>=5.2\nwagtail==7.0\n")
         self.addCleanup(tempdir.cleanup)
 
-        with self.settings(
-            BASE_DIR=tempdir.name,
-            WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
-        ):
-            with patch(
-                "wagtail_unveil.platform_data.version",
-                side_effect=lambda name: {"Django": "5.2.1", "wagtail": "7.0.2"}[name],
+        with patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"}, clear=True):
+            with self.settings(
+                BASE_DIR=tempdir.name,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
             ):
-                response = self.client.get(
-                    API_URL,
-                    HTTP_AUTHORIZATION="Bearer test-secret",
-                )
+                with patch(
+                    "wagtail_unveil.platform_data.version",
+                    side_effect=lambda name: {"Django": "5.2.1", "wagtail": "7.0.2"}[name],
+                ):
+                    response = self.client.get(
+                        API_URL,
+                        HTTP_AUTHORIZATION="Bearer test-secret",
+                    )
 
         self.assertEqual(response.status_code, 200)
         data = response.json()
@@ -68,15 +69,16 @@ class TestPlatformAPIView(TestCase):
             "Django": "5.2.1",
             "whitenoise": "6.11.1",
         }
-        with self.settings(
-            BASE_DIR=tempdir.name,
-            WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
-        ):
-            with patch("wagtail_unveil.platform_data.version", side_effect=lambda name: versions[name]):
-                response = self.client.get(
-                    API_URL,
-                    HTTP_AUTHORIZATION="Bearer test-secret",
-                )
+        with patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"}, clear=True):
+            with self.settings(
+                BASE_DIR=tempdir.name,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch("wagtail_unveil.platform_data.version", side_effect=lambda name: versions[name]):
+                    response = self.client.get(
+                        API_URL,
+                        HTTP_AUTHORIZATION="Bearer test-secret",
+                    )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -92,15 +94,16 @@ class TestPlatformAPIView(TestCase):
         tempdir, manifest_path = self._write_manifest("Django>=5.2\n")
         self.addCleanup(tempdir.cleanup)
 
-        with self.settings(
-            BASE_DIR=tempdir.name,
-            WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
-        ):
-            with patch("wagtail_unveil.platform_data.version", return_value="5.2.1"):
-                response = self.client.get(
-                    API_URL,
-                    HTTP_AUTHORIZATION="Bearer test-secret",
-                )
+        with patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"}, clear=True):
+            with self.settings(
+                BASE_DIR=tempdir.name,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch("wagtail_unveil.platform_data.version", return_value="5.2.1"):
+                    response = self.client.get(
+                        API_URL,
+                        HTTP_AUTHORIZATION="Bearer test-secret",
+                    )
 
         metadata = response.json()["metadata"]
         self.assertEqual(metadata["api_version"], "v1")
@@ -177,25 +180,27 @@ class TestPlatformAPIView(TestCase):
         tempdir, manifest_path = self._write_manifest("Django>=5.2\n", filename="requirements/base.txt")
         self.addCleanup(tempdir.cleanup)
 
-        with self.settings(
-            BASE_DIR=tempdir.name,
-            WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
-        ):
-            with patch("wagtail_unveil.platform_data.version", return_value="5.2.1"):
-                response = self.client.get(
-                    API_URL,
-                    HTTP_AUTHORIZATION="Bearer test-secret",
-                )
+        with patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"}, clear=True):
+            with self.settings(
+                BASE_DIR=tempdir.name,
+                WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=str(manifest_path),
+            ):
+                with patch("wagtail_unveil.platform_data.version", return_value="5.2.1"):
+                    response = self.client.get(
+                        API_URL,
+                        HTTP_AUTHORIZATION="Bearer test-secret",
+                    )
 
         self.assertEqual(response.json()["platform"]["python_dependencies"]["source"]["path"], "base.txt")
         self.assertNotIn(str(manifest_path), response.content.decode())
 
     def test_returns_warning_when_no_manifest_is_configured(self):
-        with self.settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=""):
-            response = self.client.get(
-                API_URL,
-                HTTP_AUTHORIZATION="Bearer test-secret",
-            )
+        with patch.dict("os.environ", {"WAGTAIL_UNVEIL_API_KEY": "test-secret"}, clear=True):
+            with self.settings(WAGTAIL_UNVEIL_PLATFORM_DEPENDENCY_FILE=""):
+                response = self.client.get(
+                    API_URL,
+                    HTTP_AUTHORIZATION="Bearer test-secret",
+                )
 
         data = response.json()
         self.assertEqual(data["platform"]["python_dependencies"]["source"]["path"], "")

--- a/uv.lock
+++ b/uv.lock
@@ -1429,7 +1429,7 @@ wheels = [
 
 [[package]]
 name = "wagtail-unveil"
-version = "0.1.0a6"
+version = "0.1.0a7"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
## Summary
- bump the package version to 0.1.0a7 and add the GitHub release body for the prerelease
- fold the current unreleased public changes into the 0.1.0a7 changelog entry
- isolate platform API view tests from ambient manifest env vars so the release validation stays deterministic

## Testing
- make test
- make lint
- uv build --sdist --wheel --out-dir /tmp/wagtail-unveil-dist-check
- uvx twine check /tmp/wagtail-unveil-dist-check/*.tar.gz /tmp/wagtail-unveil-dist-check/*.whl