### PR TITLE
Reduce release version churn and add agent release guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ Required agent self-review before handoff:
 
 Safety rule: do not start implementation for issue-scoped work on `main` when the issue is expected to have its own branch. Do not start newly scoped work on `main` without first checking whether the user wants a branch created and proposing a suitable branch title. When working on a branch with an open PR, do not ignore title/summary drift if the branch scope has materially changed.
 
+Release safety rule for agents: agents may prepare release branches, changelog/release notes, version bumps, local validation, and release preflight artifacts, but agents must not publish or attempt to publish a new package release themselves. Stop at the point where a GitHub Release needs to be created or published, and hand that step back to the user so publication happens through GitHub's release flow and workflow.
+
 For contributor commands, validation loops, and release-adjacent workflow, use `docs/contributing/development.md` as the canonical reference. For coding, testing, and documentation conventions, use `CONVENTIONS.md`.
 When changing code, treat local simplification of touched duplication or unnecessary indirection as part of completing the work, not optional polish; keep the canonical thresholds and scope limits in `CONVENTIONS.md`.
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ It exposes discovery through:
 Canonical documentation hub: [wagtail-unveil documentation](https://nm-packages.github.io/wagtail-unveil/)
 
 ```bash
-pip install wagtail-unveil==0.1.0a6
+pip install wagtail-unveil
 ```
 
-> `0.1.0a6` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
+> The current PyPI release is still an alpha intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
 > To track unreleased changes from GitHub instead, use:
 
 ```bash

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -91,7 +91,7 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
     "total_count": 190,
     "testable_count": 150,
     "untestable_count": 40,
-    "package_version": "0.1.0a6"
+    "package_version": "0.x.y"
   }
 }
 ```
@@ -171,7 +171,7 @@ curl -H "Authorization: Bearer your-secret-key" "http://localhost:8000/unveil/ap
     "total_count": 42,
     "testable_count": 31,
     "untestable_count": 11,
-    "package_version": "0.1.0a6"
+    "package_version": "0.x.y"
   }
 }
 ```
@@ -257,7 +257,7 @@ curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/unveil/api
       "sunset_on": null
     },
     "generated_at": "2026-04-08T12:34:56+00:00",
-    "package_version": "0.1.0a6"
+    "package_version": "0.x.y"
   }
 }
 ```

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -32,12 +32,15 @@ The GitHub repository and workflow identity must match exactly, or publish will 
 1. Keep `CHANGELOG.md` updated under `## Unreleased` for every merged PR landing on `main`.
 2. Update `version` in `pyproject.toml` to the intended release version.
 3. Convert the current `## Unreleased` notes in `CHANGELOG.md` into the new release entry, then leave a fresh `## Unreleased` placeholder for future work.
-4. Merge the release-prep changes to `main`.
-5. Ensure normal CI on `main` is green (`CI` workflow).
-6. Create a GitHub Release with a tag that matches the package version with `v` prefix.
-7. Use the matching `.github/release-*.md` file or the `CHANGELOG.md` entry as the GitHub Release body.
-8. Publish the GitHub Release.
-9. Confirm `.github/workflows/release.yml` succeeds and the version appears on PyPI.
+4. Review user-facing docs and examples that intentionally describe the current release, and either:
+   - update them to the new version where exact release numbers are still useful, or
+   - remove brittle hardcoded release numbers when the docs work just as well without them.
+5. Merge the release-prep changes to `main`.
+6. Ensure normal CI on `main` is green (`CI` workflow).
+7. Create a GitHub Release with a tag that matches the package version with `v` prefix.
+8. Use the matching `.github/release-*.md` file or the `CHANGELOG.md` entry as the GitHub Release body.
+9. Publish the GitHub Release.
+10. Confirm `.github/workflows/release.yml` succeeds and the version appears on PyPI.
 
 For local sandbox/test command workflows before a release, use:
 - [`development.md`](development.md) for canonical developer workflow and quickstart commands
@@ -48,6 +51,7 @@ For local sandbox/test command workflows before a release, use:
 - Add or update a `CHANGELOG.md` entry under `## Unreleased` in every PR.
 - During release prep, move or rewrite the `Unreleased` notes into the new versioned release section.
 - After release prep, keep an empty `## Unreleased` section in place for subsequent work.
+- During release prep, review any docs/examples that intentionally point at the current package release and avoid leaving stale version numbers in user-facing pages.
 
 Examples:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,10 +9,10 @@
 ## Install the Package
 
 ```bash
-pip install wagtail-unveil==0.1.0a6
+pip install wagtail-unveil
 ```
 
-> `0.1.0a6` is the current public alpha release. It is intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
+> The current PyPI release is still an alpha intended for early adopters and real-world testing, and breaking changes may still happen before a stable release.
 > To try the latest unreleased changes from GitHub instead:
 >
 > ```bash


### PR DESCRIPTION
## Summary
- remove brittle hardcoded current-release version strings from user-facing install docs
- replace API example package versions with a placeholder instead of a specific release tag
- add an explicit release-runbook reminder to review current-release docs/examples before publishing
- add an AGENTS guard that agents may prepare release metadata and validation, but must not publish new releases themselves

## Testing
- make lint
- uv build --sdist --wheel --out-dir /tmp/wagtail-unveil-dist-check
- uvx twine check /tmp/wagtail-unveil-dist-check/*.tar.gz /tmp/wagtail-unveil-dist-check/*.whl
- rg -n "0\.1\.0a6|0\.1\.0a7|v0\.1\.0a6|v0\.1\.0a7|0\.x\.y" README.md docs .github CHANGELOG.md pyproject.toml uv.lock
- rg -n "publish|release" AGENTS.md